### PR TITLE
fix: managed pool tab on profile page

### DIFF
--- a/src/components/FundCard/index.tsx
+++ b/src/components/FundCard/index.tsx
@@ -124,7 +124,7 @@ const FundCard = ({ poolAddress, link }: IFundCardProps) => {
 
   return (
     <>
-      {data && infoPool.price > '0.1' ? (
+      {data && parseFloat(infoPool.price) > 0 ? (
         <S.CardContainer isLink={!!link}>
           <Link href={link ?? ''} passHref>
             <S.CardLinkContent

--- a/src/templates/Profile/ManagedFunds/index.tsx
+++ b/src/templates/Profile/ManagedFunds/index.tsx
@@ -61,7 +61,7 @@ const ManagedFunds = () => {
     <S.ManagedFunds>
       {managerPools && managerPools.length > 0 ? (
         <S.ManagedPoolsContainer>
-          {managerPools?.map(pool => (
+          {managerPools.map(pool => (
             <FundCard
               key={pool.id}
               poolAddress={pool.id}


### PR DESCRIPTION
### Why

The manager created a pool and his pool does't list on his profile page. This occurred because there was an incorrect check before listing the pools

### Changes

Check if the price is greater than 0 and not greater than '0.1'.