### PR TITLE
Refactor: change useCommunity query

### DIFF
--- a/src/gql/generated/backendApi.ts
+++ b/src/gql/generated/backendApi.ts
@@ -1701,7 +1701,7 @@ export type Pool = {
   brokers: Array<Broker>
   chain?: Maybe<Chain>
   chainId?: Maybe<Scalars['Int']['output']>
-  chain_id?: Maybe<Scalars['Int']['output']>
+  chain_id: Scalars['Int']['output']
   /**
    * Controller contract that controls the vault
    *

--- a/src/gql/generated/kassandraApi.ts
+++ b/src/gql/generated/kassandraApi.ts
@@ -1635,6 +1635,7 @@ export type Kassandra = {
   num_managers: Scalars['Int']['output']
   num_tx: Scalars['BigInt']['output']
   pool_count: Scalars['Int']['output']
+  pool_featured_count: Scalars['Int']['output']
   total_fees_aum_kassandra_btc: Scalars['BigDecimal']['output']
   total_fees_aum_kassandra_usd: Scalars['BigDecimal']['output']
   total_fees_aum_manager_btc: Scalars['BigDecimal']['output']
@@ -1746,6 +1747,14 @@ export type Kassandra_Filter = {
   pool_count_lte?: InputMaybe<Scalars['Int']['input']>
   pool_count_not?: InputMaybe<Scalars['Int']['input']>
   pool_count_not_in?: InputMaybe<Array<Scalars['Int']['input']>>
+  pool_featured_count?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_gt?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_gte?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_in?: InputMaybe<Array<Scalars['Int']['input']>>
+  pool_featured_count_lt?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_lte?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_not?: InputMaybe<Scalars['Int']['input']>
+  pool_featured_count_not_in?: InputMaybe<Array<Scalars['Int']['input']>>
   total_fees_aum_kassandra_btc?: InputMaybe<Scalars['BigDecimal']['input']>
   total_fees_aum_kassandra_btc_gt?: InputMaybe<Scalars['BigDecimal']['input']>
   total_fees_aum_kassandra_btc_gte?: InputMaybe<Scalars['BigDecimal']['input']>
@@ -1923,6 +1932,7 @@ export type Kassandra_OrderBy =
   | 'num_managers'
   | 'num_tx'
   | 'pool_count'
+  | 'pool_featured_count'
   | 'total_fees_aum_kassandra_btc'
   | 'total_fees_aum_kassandra_usd'
   | 'total_fees_aum_manager_btc'
@@ -2555,6 +2565,7 @@ export type Pool = {
   price_btc: Scalars['BigDecimal']['output']
   price_candles: Array<Candle>
   price_usd: Scalars['BigDecimal']['output']
+  short_summary?: Maybe<Scalars['String']['output']>
   /**
    * Address that can manage the assets in the pool
    *
@@ -3270,6 +3281,26 @@ export type Pool_Filter = {
   price_usd_lte?: InputMaybe<Scalars['BigDecimal']['input']>
   price_usd_not?: InputMaybe<Scalars['BigDecimal']['input']>
   price_usd_not_in?: InputMaybe<Array<Scalars['BigDecimal']['input']>>
+  short_summary?: InputMaybe<Scalars['String']['input']>
+  short_summary_contains?: InputMaybe<Scalars['String']['input']>
+  short_summary_contains_nocase?: InputMaybe<Scalars['String']['input']>
+  short_summary_ends_with?: InputMaybe<Scalars['String']['input']>
+  short_summary_ends_with_nocase?: InputMaybe<Scalars['String']['input']>
+  short_summary_gt?: InputMaybe<Scalars['String']['input']>
+  short_summary_gte?: InputMaybe<Scalars['String']['input']>
+  short_summary_in?: InputMaybe<Array<Scalars['String']['input']>>
+  short_summary_lt?: InputMaybe<Scalars['String']['input']>
+  short_summary_lte?: InputMaybe<Scalars['String']['input']>
+  short_summary_not?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_contains?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_contains_nocase?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_ends_with?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_in?: InputMaybe<Array<Scalars['String']['input']>>
+  short_summary_not_starts_with?: InputMaybe<Scalars['String']['input']>
+  short_summary_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>
+  short_summary_starts_with?: InputMaybe<Scalars['String']['input']>
+  short_summary_starts_with_nocase?: InputMaybe<Scalars['String']['input']>
   strategy?: InputMaybe<Scalars['String']['input']>
   strategy_contains?: InputMaybe<Scalars['String']['input']>
   strategy_contains_nocase?: InputMaybe<Scalars['String']['input']>
@@ -3719,6 +3750,7 @@ export type Pool_OrderBy =
   | 'price_btc'
   | 'price_candles'
   | 'price_usd'
+  | 'short_summary'
   | 'strategy'
   | 'summary'
   | 'supply'
@@ -4950,6 +4982,7 @@ export type Token = {
    *
    */
   id: Scalars['ID']['output']
+  in_pool: Scalars['Boolean']['output']
   is_wrap_token: Scalars['Int']['output']
   logo?: Maybe<Scalars['String']['output']>
   name: Scalars['String']['output']
@@ -5015,6 +5048,10 @@ export type Token_Filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>
   id_not?: InputMaybe<Scalars['ID']['input']>
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>
+  in_pool?: InputMaybe<Scalars['Boolean']['input']>
+  in_pool_in?: InputMaybe<Array<Scalars['Boolean']['input']>>
+  in_pool_not?: InputMaybe<Scalars['Boolean']['input']>
+  in_pool_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>
   is_wrap_token?: InputMaybe<Scalars['Int']['input']>
   is_wrap_token_gt?: InputMaybe<Scalars['Int']['input']>
   is_wrap_token_gte?: InputMaybe<Scalars['Int']['input']>
@@ -5112,6 +5149,7 @@ export type Token_OrderBy =
   | 'coingecko_id'
   | 'decimals'
   | 'id'
+  | 'in_pool'
   | 'is_wrap_token'
   | 'logo'
   | 'name'
@@ -6684,15 +6722,13 @@ export type CommunityPoolsQuery = {
     now: Array<{ __typename?: 'Candle'; timestamp: number; close: string }>
     day: Array<{ __typename?: 'Candle'; timestamp: number; close: string }>
     month: Array<{ __typename?: 'Candle'; timestamp: number; close: string }>
-    weight_goals: Array<{
-      __typename?: 'WeightGoalPoint'
-      weights: Array<{
-        __typename?: 'WeightGoal'
-        asset: {
-          __typename?: 'Asset'
-          token: { __typename?: 'Token'; logo?: string | null }
-        }
-      }>
+    underlying_assets: Array<{
+      __typename?: 'Asset'
+      token: {
+        __typename?: 'Token'
+        logo?: string | null
+        wraps?: { __typename?: 'Token'; logo?: string | null } | null
+      }
     }>
   }>
 }
@@ -8072,12 +8108,11 @@ export const CommunityPoolsDocument = gql`
         timestamp
         close
       }
-      weight_goals(orderBy: end_timestamp, orderDirection: desc, first: 1) {
-        weights(orderBy: weight_normalized, orderDirection: desc) {
-          asset {
-            token {
-              logo
-            }
+      underlying_assets {
+        token {
+          logo
+          wraps {
+            logo
           }
         }
       }

--- a/src/gql/queries/kassandra/communityPools-kassandra.gql
+++ b/src/gql/queries/kassandra/communityPools-kassandra.gql
@@ -59,12 +59,11 @@ query CommunityPools(
         timestamp
         close
       }
-      weight_goals(orderBy: end_timestamp, orderDirection: desc, first: 1) {
-        weights(orderBy: weight_normalized, orderDirection: desc) {
-          asset {
-            token {
-              logo
-            }
+      underlying_assets {
+        token {
+          logo
+          wraps {
+            logo
           }
         }
       }

--- a/src/templates/Explore/CommunityPoolsTable/index.tsx
+++ b/src/templates/Explore/CommunityPoolsTable/index.tsx
@@ -59,18 +59,16 @@ type IPoolsInfosProps = {
     timestamp: number
     close: any
   }[]
-  weight_goals: {
-    __typename?: 'WeightGoalPoint' | undefined
-    weights: {
-      __typename?: 'WeightGoal' | undefined
-      asset: {
-        __typename?: 'Asset' | undefined
-        token: {
-          __typename?: 'Token' | undefined
-          logo?: string | null | undefined
-        }
-      }
-    }[]
+  underlying_assets: {
+    token: {
+      logo?: string | null | undefined
+      wraps?:
+        | {
+            logo?: string | null | undefined
+          }
+        | null
+        | undefined
+    }
   }[]
 }
 
@@ -101,14 +99,15 @@ const CommunityPoolsTable = ({
   const [viewPool, setViewPool] = React.useState<{
     price: string
     tvl: string
-    assets: {
-      __typename?: 'WeightGoal' | undefined
-      asset: {
-        __typename?: 'Asset' | undefined
-        token: {
-          __typename?: 'Token' | undefined
-          logo?: string | null | undefined
-        }
+    underlying_assets: {
+      token: {
+        logo?: string | null | undefined
+        wraps?:
+          | {
+              logo?: string | null | undefined
+            }
+          | null
+          | undefined
       }
     }[]
     volume: string
@@ -117,11 +116,12 @@ const CommunityPoolsTable = ({
   }>({
     price: '',
     tvl: '',
-    assets: [
+    underlying_assets: [
       {
-        asset: {
-          token: {
-            logo: ''
+        token: {
+          logo: undefined,
+          wraps: {
+            logo: undefined
           }
         }
       }
@@ -149,14 +149,15 @@ const CommunityPoolsTable = ({
     logo: string | null,
     price: string,
     tvl: string,
-    assets: {
-      __typename?: 'WeightGoal' | undefined
-      asset: {
-        __typename?: 'Asset' | undefined
-        token: {
-          __typename?: 'Token' | undefined
-          logo?: string | null | undefined
-        }
+    underlying_assets: {
+      token: {
+        logo?: string | null | undefined
+        wraps?:
+          | {
+              logo?: string | null | undefined
+            }
+          | null
+          | undefined
       }
     }[],
     volume: string,
@@ -168,11 +169,11 @@ const CommunityPoolsTable = ({
       name: token
     })
     setViewPool({
-      price: price,
-      tvl: tvl,
-      assets: assets,
-      volume: volume,
-      monthly: monthly,
+      price,
+      tvl,
+      underlying_assets,
+      volume,
+      monthly,
       ['24h']: day
     })
     setIsOpen(true)
@@ -308,14 +309,20 @@ const CommunityPoolsTable = ({
                     <S.TD isView={inViewCollum === 3}>
                       <S.Container>
                         <S.CoinImageContainer>
-                          {pool.weight_goals[0].weights.map((coin, index) => {
+                          {pool.underlying_assets.map((coin, index) => {
                             return (
                               <S.CoinImageWrapper
-                                key={coin.asset?.token?.logo}
+                                key={
+                                  coin?.token?.wraps?.logo ?? coin?.token?.logo
+                                }
                                 position={index}
                               >
                                 <Image
-                                  src={coin.asset?.token?.logo || notFoundIcon}
+                                  src={
+                                    coin?.token?.logo ??
+                                    coin?.token?.wraps?.logo ??
+                                    notFoundIcon
+                                  }
                                   layout="fill"
                                 />
                               </S.CoinImageWrapper>
@@ -382,7 +389,7 @@ const CommunityPoolsTable = ({
                           pool?.logo || '',
                           pool.price_usd,
                           pool.total_value_locked_usd,
-                          pool.weight_goals[0].weights,
+                          pool.underlying_assets,
                           pool.volumes[0].volume_usd,
                           pool.month[0].close
                             ? calcChange(
@@ -439,14 +446,20 @@ const CommunityPoolsTable = ({
           <ValueContainerMobile>
             <S.CoinModalContainer>
               <S.CoinImageContainer>
-                {viewPool.assets.map((coin, index) => {
+                {viewPool.underlying_assets.map((coin, index) => {
                   return (
                     <S.CoinImageWrapper
-                      key={coin.asset?.token?.logo || index}
+                      key={
+                        coin?.token?.wraps?.logo ?? coin?.token?.logo ?? index
+                      }
                       position={index}
                     >
                       <Image
-                        src={coin.asset?.token?.logo || notFoundIcon}
+                        src={
+                          coin?.token?.logo ??
+                          coin?.token?.wraps?.logo ??
+                          notFoundIcon
+                        }
                         width={18}
                         height={18}
                       />


### PR DESCRIPTION
## Why
Previously, in the useCommunityPool query, the retrieval of token logos was based on the weight_goal reference. Now, it has been updated to retrieve token logos based on the underlying_assets reference.
 
## Changes
1.  change the way of retrieving assets from the weight_gols pool to underlying_assets in the useCommunityPools query

