### PR TITLE
fix: getReward function in useStakingInfo hook

### DIFF
--- a/src/hooks/useStakingInfo.tsx
+++ b/src/hooks/useStakingInfo.tsx
@@ -23,7 +23,7 @@ const useStakingInfo = (chaindId: number, pid?: number) => {
   )
 
   function handleClain(poolSymbol: string) {
-    if (!pid) return
+    if (pid !== 0 && !pid) return
 
     staking.getReward(
       pid,


### PR DESCRIPTION
## Why

The getReward function in the useStakingInfo hook was not working properly in the KACY-WETH LP pool.

## Changes
-fix getReward function in useStakingInfo hook.