### PR TITLE
fix: add dependency in useEffect in usePrivateInvestors

### DIFF
--- a/src/hooks/usePrivateInvestors.tsx
+++ b/src/hooks/usePrivateInvestors.tsx
@@ -15,7 +15,7 @@ const usePrivateInvestors = (contractAddress: string, chainId = 137) => {
 
   React.useEffect(() => {
     setContract(new Contract(contractAddress, PrivateInvestors, readProvider))
-  }, [contractAddress])
+  }, [contractAddress, chainId])
 
   return React.useMemo(() => {
     // Read functions

--- a/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
@@ -778,7 +778,8 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
       ) : chainId === pool?.chain_id ? (
         pool.is_private_pool &&
         !privateInvestors.some(
-          address => address.toLowerCase() === wallet?.accounts[0].address
+          address =>
+            address.toLowerCase() === wallet?.accounts[0].address.toLowerCase()
         ) ? (
           <Tippy
             allowHTML={true}

--- a/src/templates/PoolV2/NewPoolOperations/Form/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/index.tsx
@@ -93,7 +93,7 @@ const Form = ({ typeAction, typeWithdraw }: IFormProps) => {
   React.useEffect(() => {
     if (!pool?.is_private_pool) return
     setAddressesOfPrivateInvestors()
-  }, [wallet, pool])
+  }, [wallet, pool, privateAddresses])
 
   React.useEffect(() => {
     handleGetSigner()


### PR DESCRIPTION
## Why
 yesterday we had to upload this hotfix to master because transfer investors were unable to invest in their private pool

## Changes

- add dependency in useEffect in usePrivateInvestors