### PR TITLE
refactor: add text on WarningCard in pool page

### DIFF
--- a/src/templates/PoolV2/Hero/index.tsx
+++ b/src/templates/PoolV2/Hero/index.tsx
@@ -144,13 +144,17 @@ const Hero = ({ handleClickStakeButton }: IHeroProps) => {
         )}
       </S.SubTitleConteiner>
 
-      {/* {pool?.pool_version === 1 && (
+      {pool?.pool_version === 1 && (
         <S.WarningCardContainer>
           <WarningCard>
-            <p>This pool has been deprecated.</p>
+            <p>
+              Please do not make deposits in this pool, it is a previous version
+              and is being discontinued. We have experienced issues with YY
+              tokens. Only withdrawals should be made. Avoid making deposits.
+            </p>
           </WarningCard>
         </S.WarningCardContainer>
-      )} */}
+      )}
 
       {pool ? (
         <S.Summary>{pool?.short_summary}</S.Summary>

--- a/src/templates/PoolV2/index.tsx
+++ b/src/templates/PoolV2/index.tsx
@@ -15,6 +15,7 @@ import Faqs from './Faqs'
 import Staking from './Staking'
 import Overview from './Overview'
 import ShareAndEarn from './ShareAndEarn'
+import Activity from './Activity'
 
 import { setTokensSwapProvider } from '@/store/reducers/tokenListSwapProvider'
 import useMatomoEcommerce from '@/hooks/useMatomoEcommerce'
@@ -23,7 +24,6 @@ import { useAppDispatch } from '@/store/hooks'
 import { useTokenSwap } from '@/hooks/query/useTokensSwap'
 
 import { NATIVE_ADDRESS } from '@/constants/tokenAddresses'
-import Activity from './Activity'
 
 import {
   ContractsIcon,
@@ -172,7 +172,6 @@ const Pool = () => {
             .mul(100)
             .toFixed(2),
           depositFee: Big(pool?.fee_join_manager ?? '0')
-            .add(pool?.fee_join_broker ?? '0')
             .mul(100)
             .toFixed(2),
           managerShare: Big(pool?.fee_join_broker ?? '0')


### PR DESCRIPTION
## Why

Add a warning card to PoolV1 on the new pool page to alert customers not to deposit into the pool as it has been deprecated.

## Changes
- Add text on WarningCard in pool page.
