### PR TITLE
refactor: ensure to show the manager's name or address on the FundCard

### DIFF
--- a/src/components/FundCard/index.tsx
+++ b/src/components/FundCard/index.tsx
@@ -18,6 +18,7 @@ import arrowAscend from '@assets/notificationStatus/arrow-ascend.svg'
 import arrowDescend from '@assets/notificationStatus/arrow-descend.svg'
 
 import { UnderlyingAssetsInfoType } from '@/utils/updateAssetsToV2'
+import substr from '@/utils/substr'
 
 import * as S from './styles'
 
@@ -167,8 +168,8 @@ const FundCard = ({ poolAddress, link }: IFundCardProps) => {
 
               <S.CardBody>
                 <S.FundName>
-                  <h3>{data?.name}</h3>
-                  <span>by {data?.founded_by ?? 'Community'}</span>
+                  <h3>{data.name}</h3>
+                  <span>by {data.manager.nickname ?? substr(data.manager.id)}</span>
                 </S.FundName>
 
                 <S.FundStatusContainer>

--- a/src/components/FundCard/index.tsx
+++ b/src/components/FundCard/index.tsx
@@ -169,7 +169,9 @@ const FundCard = ({ poolAddress, link }: IFundCardProps) => {
               <S.CardBody>
                 <S.FundName>
                   <h3>{data.name}</h3>
-                  <span>by {data.manager.nickname ?? substr(data.manager.id)}</span>
+                  <span>
+                    by {data.manager.nickname ?? substr(data.manager.id)}
+                  </span>
                 </S.FundName>
 
                 <S.FundStatusContainer>

--- a/src/gql/generated/kassandraApi.ts
+++ b/src/gql/generated/kassandraApi.ts
@@ -8065,6 +8065,7 @@ export type FundCardQuery = {
     featured: boolean
     total_value_locked_usd: string
     strategy: string
+    manager: { __typename?: 'Manager'; id: string; nickname?: string | null }
     chain: { __typename?: 'Chain'; logo?: string | null }
     price_candles: Array<{
       __typename?: 'Candle'
@@ -9503,6 +9504,10 @@ export const FundCardDocument = gql`
       price_usd
       pool_version
       featured
+      manager {
+        id
+        nickname
+      }
       chain {
         logo: icon
       }

--- a/src/gql/queries/kassandra/fundCard-kassandra.gql
+++ b/src/gql/queries/kassandra/fundCard-kassandra.gql
@@ -15,14 +15,18 @@ query FundCard(
       price_usd # pool asset price
       pool_version
       featured
+      manager {
+        id
+        nickname
+      }
+      chain {
+        logo: icon
+      }
       # price candlestick
       # just taking the close value can make a line graph
       # base can be usd or btc
       # period is in seconds, 5m, 15m, 1h, 4h, 1d, 7d
       # timestamp_gt it's since when to catch
-      chain {
-        logo: icon
-      }
       price_candles(
         where: {
           base: "usd"


### PR DESCRIPTION
## Why

When a pool is featured, it was displayed in FundCard as being managed by Kassandra. Featured pools can now also be a community pool

## Changes

FundCard show 'by manger name' or 'by manager address'
