### PR TITLE
Fix: strategist doesnt update after ownership transfer

### DIFF
--- a/src/hooks/useManagePoolController.tsx
+++ b/src/hooks/useManagePoolController.tsx
@@ -178,11 +178,13 @@ function managePoolFunctions(
   ) => {
     try {
       const tx = await controller.send.setStrategist(address)
-      await txNotification(
+      const response = await txNotification(
         tx,
         { sucess: transactionText.success },
         { onSuccess, onFail }
       )
+
+      return response
     } catch (error) {
       const contractInfo = {
         contractName: 'KassandraController',
@@ -225,11 +227,13 @@ function managePoolFunctions(
   ) => {
     try {
       const tx = await controller.send.transferOwnership(address)
-      await txNotification(
+      const response = await txNotification(
         tx,
         { sucess: transactionText.success },
         { onSuccess, onFail }
       )
+
+      return response
     } catch (error) {
       const contractInfo = {
         contractName: 'KassandraController',

--- a/src/services/operationV2.ts
+++ b/src/services/operationV2.ts
@@ -364,21 +364,21 @@ export default class operationV2 implements IOperations {
       // )
 
       const amountsOutList = response.amountsOut.slice(1)
-      const poolTokenList = this.poolInfo.tokens.sort((a, b) =>
-        a.token.id.toLowerCase() > b.token.id.toLowerCase() ? 1 : -1
-      )
 
       const amountsOutListFormatted: string[] = []
-      const assets = poolTokenList.map((token, index) => {
+      const assets = this.poolInfo.tokensAddresses.map((token, index) => {
         const amount = Big(amountsOutList[index].toString())
           .mul(10000 - 1)
           .div(10000)
           .toFixed(0)
         amountsOutListFormatted.push(amount)
 
+        const tokenInfo = this.poolInfo.tokens.find(
+          item => item.token.id === token
+        )
         return {
-          id: token.token.wraps?.id ?? token.token.id,
-          decimals: token.token.decimals,
+          id: tokenInfo?.token.wraps?.id ?? tokenInfo?.token.id ?? '',
+          decimals: tokenInfo?.token.decimals ?? 18,
           amount
         }
       })

--- a/src/templates/Manage/CreatePool/AssetsTable/index.tsx
+++ b/src/templates/Manage/CreatePool/AssetsTable/index.tsx
@@ -130,7 +130,12 @@ const AssetsTable = ({ tokensData, priceList, tokenBalance }: IAssetsTable) => {
                     />
                   </S.Td>
                   <S.Td className="price">
-                    ${priceList ? priceList[coin.id.toLowerCase()]?.usd : 0}
+                    $
+                    {priceList
+                      ? Big(
+                          priceList[coin.id.toLowerCase()]?.usd.toFixed(10) ?? 0
+                        ).toFixed()
+                      : 0}
                   </S.Td>
                   <S.Td className="marketCap">
                     $

--- a/src/templates/PoolManager/Details/index.tsx
+++ b/src/templates/PoolManager/Details/index.tsx
@@ -57,19 +57,24 @@ const Details = () => {
       success: 'New strategist added!'
     }
 
-    await setStrategist(address, transactionText)
+    return await setStrategist(address, transactionText)
   }
 
   async function handleTransferOwnership(address: string) {
-    const transactionText = {
-      success: 'New manager added!'
-    }
+    const response = await handleChangeStrategy(address)
 
     function handleSuccess() {
       setcurrentCandidate(address)
     }
 
-    await transferOwnership(address, transactionText, handleSuccess)
+    const transactionSuccess = 1
+    if (response?.status === transactionSuccess) {
+      const transactionText = {
+        success: 'New manager added!'
+      }
+
+      await transferOwnership(address, transactionText, handleSuccess)
+    }
   }
 
   async function getCurrentManagerCandidate() {

--- a/src/templates/PoolV2/Faqs/index.tsx
+++ b/src/templates/PoolV2/Faqs/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Big from 'big.js'
 
 import QuestionsAndAnswers from '@/components/QuestionsAndAnswers'
 
@@ -50,7 +51,13 @@ const Faqs = ({
   const faqListRight = [
     {
       question: `What are the fees associated with this ${poolName} portfolio?`,
-      answers: `The fees include: \n\n${fee.depositFee}% deposit fee for the manager of which ${fee.managerShare}% can go to a person who shared the pool.\n${fee.managementFee}% annualized management fee set by the manager. \n0.5% annualized fee for Kassandra.`
+      answers: `The fees include: \n\n${Big(fee.depositFee)
+        .add(fee.managerShare)
+        .toFixed(2)}% deposit fee, of which ${
+        fee.managerShare
+      }% can go to a person who shared the pool.\n${
+        fee.managementFee
+      }% annualized management fee set by the manager, of which \n0.5% is allocated as an annualized fee for Kassandra.`
     },
     {
       question: 'Is this pool public or private?',


### PR DESCRIPTION
## Why

The strategist isn't updating after the ownership transfer, and some bug fixes on the pool screen have been addressed.
Fixes 

## Changes

Please delete options that are not relevant.

- strategist doesnt update after ownership transfer
- update price formatting in the AssetsTable table
- update faq text on pool page
- fix token order in single asset withdraw process