### PR TITLE
refactor: pass transaction value to the approve function

### DIFF
--- a/src/components/Modals/ModalBridge/index.tsx
+++ b/src/components/Modals/ModalBridge/index.tsx
@@ -113,7 +113,8 @@ const ModalBridge = ({ setIsModalOpen }: IModalBridgeProps) => {
         }
       )
 
-      await approve(networks[43114].kacyOFT)
+      const valueMult = Big(value).mul(Big(10).pow(18)).toFixed(0)
+      await approve(networks[43114].kacyOFT, BigInt(valueMult))
 
       const amount = await allowance(
         networks[43114].kacyOFT,

--- a/src/components/Modals/ModalStakeAndWithdraw/index.tsx
+++ b/src/components/Modals/ModalStakeAndWithdraw/index.tsx
@@ -47,7 +47,7 @@ interface IModalStakeProps {
   setStakeTransaction: React.Dispatch<React.SetStateAction<typeTransaction>>
   setModalOpen: React.Dispatch<React.SetStateAction<boolean>>
   updateAllowance: () => Promise<void>
-  handleApprove: () => Promise<void>
+  handleApprove: (value: Big) => Promise<void>
   getUserInfoAboutPool: () => Promise<void>
 }
 
@@ -306,7 +306,7 @@ const ModalStakeAndWithdraw = ({
                   disabledNoEvent={amountStake.gt(balance)}
                   background="secondary"
                   fullWidth
-                  onClick={handleApprove}
+                  onClick={() => handleApprove(amountStake)}
                 />
               ) : (
                 <Button

--- a/src/components/StakeCard/index.tsx
+++ b/src/components/StakeCard/index.tsx
@@ -148,10 +148,11 @@ const StakeCard = ({ pool, kacyPrice, poolPrice }: IStakingProps) => {
     setAmountApproveKacyStaking(Big(allowance))
   }
 
-  async function handleApproveKacy() {
+  async function handleApproveKacy(value: Big) {
     const allowance = await stakingInfo.handleApprove(
       poolInfo.stakingToken,
-      pool?.symbol ?? ''
+      pool?.symbol ?? '',
+      value
     )
 
     setAmountApproveKacyStaking(Big(allowance))

--- a/src/hooks/useERC20.tsx
+++ b/src/hooks/useERC20.tsx
@@ -89,7 +89,7 @@ function ERC20Contract(
       return receipt
     } catch (error) {
       const contractInfo = {
-        contractName: 'ERC20  ',
+        contractName: 'ERC20',
         functionName: 'approve'
       }
       transactionErrors(error, contractInfo, callbacks?.onFail)

--- a/src/hooks/useERC20.tsx
+++ b/src/hooks/useERC20.tsx
@@ -77,19 +77,20 @@ function ERC20Contract(
 
   const approve = async (
     spenderAddress: string,
+    value: bigint,
     message?: MessageType,
     callbacks?: CallbacksType
   ): Promise<ContractTransactionReceipt | null> => {
     if (!txNotification || !transactionErrors) return null
 
     try {
-      const tx = await contract.send.approve(spenderAddress, MaxUint256)
+      const tx = await contract.send.approve(spenderAddress, value)
       const receipt = await txNotification(tx, message, callbacks)
       return receipt
     } catch (error) {
       const contractInfo = {
-        contractName: 'kacyOFT',
-        functionName: 'sendFrom'
+        contractName: 'ERC20  ',
+        functionName: 'approve'
       }
       transactionErrors(error, contractInfo, callbacks?.onFail)
       return null

--- a/src/hooks/useStakingInfo.tsx
+++ b/src/hooks/useStakingInfo.tsx
@@ -38,7 +38,11 @@ const useStakingInfo = (chaindId: number, pid?: number) => {
     )
   }
 
-  async function handleApprove(stakingToken: string, poolSymbol: string) {
+  async function handleApprove(
+    stakingToken: string,
+    poolSymbol: string,
+    value: Big
+  ) {
     const erc20 = await ERC20(stakingToken, networkChain.rpc, {
       transactionErrors: transaction.transactionErrors,
       txNotification: transaction.txNotification,
@@ -47,6 +51,7 @@ const useStakingInfo = (chaindId: number, pid?: number) => {
 
     await erc20.approve(
       networkChain.stakingContract ?? '',
+      BigInt(value.toFixed(0)),
       {
         pending: `Waiting approval of ${poolSymbol}...`,
         sucess: `Approval of ${poolSymbol} confirmed`

--- a/src/templates/Manage/CreatePool/index.tsx
+++ b/src/templates/Manage/CreatePool/index.tsx
@@ -298,6 +298,7 @@ const CreatePool = ({ setIsCreatePool }: ICreatePoolProps) => {
 
       const receipt = await approve(
         factory,
+        BigInt(token.amount),
         {},
         {
           onFail: handleFail

--- a/src/templates/PoolManager/ManageAssets/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/index.tsx
@@ -612,6 +612,7 @@ const ManageAssets = ({ setIsOpenManageAssets }: IManageAssetsProps) => {
     )
     const receipt = await approve(
       poolInfo[0]?.controller,
+      BigInt(token.amount),
       {},
       {
         onFail: handleFail

--- a/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
@@ -453,6 +453,7 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
         )
         approve(
           operation.contractAddress,
+          BigInt(Big(amountTokenIn).toFixed(0)),
           {
             error: `Failed to approve ${tokenSelect.symbol}`,
             pending: `Waiting approval of ${tokenSelect.symbol}...`,

--- a/src/templates/PoolV2/NewPoolOperations/Form/Withdraw/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/Withdraw/index.tsx
@@ -237,6 +237,7 @@ const Withdraw = ({ typeWithdraw, typeAction }: IWithdrawProps) => {
 
         approve(
           proxyInvest,
+          BigInt(Big(amountTokenIn).toFixed(0)),
           {
             error: `Failed to approve ${pool?.symbol}`,
             pending: `Waiting approval of ${pool?.symbol}...`,

--- a/src/templates/PoolV2/Staking/PoolStakingCard/index.tsx
+++ b/src/templates/PoolV2/Staking/PoolStakingCard/index.tsx
@@ -95,10 +95,11 @@ const PoolStakingCard = ({
     setAmountApproveStaking(Big(allowance))
   }
 
-  async function handleApproveStaking() {
+  async function handleApproveStaking(value: Big) {
     const allowance = await stakingInfo.handleApprove(
       poolInfo.stakingToken,
-      pool?.symbol ?? ''
+      pool?.symbol ?? '',
+      value
     )
 
     setAmountApproveStaking(Big(allowance))


### PR DESCRIPTION
## Why

Previously, we were passing maxUint256 as a parameter to the approve function. Now, we've updated it so that the approve function receives the specific value to be used in the transaction for approval.
