### PR TITLE
feat: notify users rpc error 429

### DIFF
--- a/src/components/Header/HeaderButtons/index.tsx
+++ b/src/components/Header/HeaderButtons/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useConnectWallet } from '@web3-onboard/react'
-import { JsonRpcProvider, getAddress } from 'ethers'
+import { JsonRpcProvider, Network, getAddress } from 'ethers'
 
 import { networks } from '@/constants/tokenAddresses'
 import { getDateDiff } from '@/utils/date'
@@ -127,10 +127,14 @@ const HeaderButtons = ({ setIsChooseNetwork }: IHeaderButtonsProps) => {
       return
     }
 
+    const networkInfo = networks[Number(wallet?.chains[0].id ?? '43114')]
+
     const chaindId =
       networks[Number(wallet?.chains[0].id ?? '')]?.chainId ?? 43114
-
-    const provider = new JsonRpcProvider(networks[chaindId].rpc)
+    const network = new Network(networkInfo.chainName, networkInfo.chainId)
+    const provider = new JsonRpcProvider(networks[chaindId].rpc, network, {
+      staticNetwork: network
+    })
     const subgraphTimestamp = await provider.getBlock(
       BigInt(latestBlockData?.subgraphBlock)
     )

--- a/src/components/Modals/ModalBridge/index.tsx
+++ b/src/components/Modals/ModalBridge/index.tsx
@@ -74,7 +74,7 @@ const ModalBridge = ({ setIsModalOpen }: IModalBridgeProps) => {
         return
       }
 
-      const contract = await ERC20(chain.kacyAddress, chain.rpc, {
+      const contract = await ERC20(chain.kacyAddress, chain.chainId, {
         wallet: wallet,
         txNotification: txNotification,
         transactionErrors: transactionErrors
@@ -105,7 +105,7 @@ const ModalBridge = ({ setIsModalOpen }: IModalBridgeProps) => {
 
       const { approve, allowance } = await ERC20(
         networks[43114].kacyAddress,
-        networks[43114].rpc,
+        networks[43114].chainId,
         {
           wallet: wallet,
           txNotification: txNotification,

--- a/src/components/Modals/ModalKacy/index.tsx
+++ b/src/components/Modals/ModalKacy/index.tsx
@@ -71,7 +71,7 @@ const ModalKacy = () => {
         const chain = networks[kacy.chain]
 
         if (chain.kacyAddress) {
-          const contract = await ERC20(chain.kacyAddress, chain.rpc)
+          const contract = await ERC20(chain.kacyAddress, chain.chainId)
           const balance = await contract.balance(wallet)
 
           Object.assign(kacyAmountInWallet, {

--- a/src/components/Modals/ModalStakeAndWithdraw/index.tsx
+++ b/src/components/Modals/ModalStakeAndWithdraw/index.tsx
@@ -195,7 +195,7 @@ const ModalStakeAndWithdraw = ({
 
   async function getBalance() {
     if (wallet?.provider && stakeTransaction === typeTransaction.STAKING) {
-      const erc20 = await ERC20(stakingToken, networkChain.rpc)
+      const erc20 = await ERC20(stakingToken, networkChain.chainId)
 
       const balanceKacy = await erc20.balance(wallet?.accounts[0].address)
       setBalance(Big(balanceKacy))

--- a/src/components/StakeCard/index.tsx
+++ b/src/components/StakeCard/index.tsx
@@ -138,7 +138,7 @@ const StakeCard = ({ pool, kacyPrice, poolPrice }: IStakingProps) => {
   }
 
   async function updateAllowance() {
-    const erc20 = await ERC20(poolInfo.stakingToken, networkChain.rpc)
+    const erc20 = await ERC20(poolInfo.stakingToken, networkChain.chainId)
 
     const allowance = await erc20.allowance(
       stakingContract,

--- a/src/constants/tokenAddresses.ts
+++ b/src/constants/tokenAddresses.ts
@@ -178,7 +178,7 @@ export const networks: NetworkType = {
   '43114': {
     chainId: 43114,
     chainName: 'Avalanche',
-    rpc: 'https://rpc.ankr.com/avalanche',
+    rpc: 'https://avalanche.public-rpc.com',
     kacyAddress: Kacy,
     blockExplorer: 'https://snowtrace.io',
     coingecko: 'avalanche',

--- a/src/hooks/useBatchRequests.tsx
+++ b/src/hooks/useBatchRequests.tsx
@@ -1,11 +1,14 @@
-import { JsonRpcProvider, Contract } from 'ethers'
+import { JsonRpcProvider, Contract, Network } from 'ethers'
 
 import { NATIVE_ADDRESS, networks } from '@/constants/tokenAddresses'
 import ERC20 from '@/constants/abi/ERC20.json'
 
 const useBatchRequests = (networkId: number) => {
-  const rpcURL = networks[networkId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[networkId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   // Batch request to get user balance from an array of tokens
   const balances = async (userWalletAddress: string, addresses: string[]) => {

--- a/src/hooks/useCreatePool.tsx
+++ b/src/hooks/useCreatePool.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { JsonRpcProvider, BrowserProvider, Contract, ethers } from 'ethers'
+import {
+  JsonRpcProvider,
+  BrowserProvider,
+  Contract,
+  ethers,
+  Network
+} from 'ethers'
 import { useConnectWallet } from '@web3-onboard/react'
 import KassandraManagedControllerFactoryAbi from '@/constants/abi/KassandraManagedControllerFactory.json'
 
@@ -44,7 +50,10 @@ const useCreatePool = (chainId: number) => {
   const network = networks[chainId]
   const rpcURL = network.rpc
   const factoryAddress = network.factory
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = new Network(network.chainName, network.chainId)
+  const readProvider = new JsonRpcProvider(rpcURL, networkInfo, {
+    staticNetwork: networkInfo
+  })
 
   const [contract, setContract] = React.useState({
     send: new Contract(

--- a/src/hooks/useERC20.tsx
+++ b/src/hooks/useERC20.tsx
@@ -6,7 +6,8 @@ import {
   MaxUint256,
   ContractTransactionResponse,
   ErrorCode,
-  ContractTransactionReceipt
+  ContractTransactionReceipt,
+  Network
 } from 'ethers'
 import { useConnectWallet } from '@web3-onboard/react'
 import { WalletState } from '@web3-onboard/core'
@@ -108,11 +109,15 @@ function ERC20Contract(
   }
 }
 
-const useERC20 = (address: string, rpcURL = networks[137].rpc) => {
+const useERC20 = (address: string, chainId = 137) => {
   const [{ wallet }] = useConnectWallet()
   const { txNotification, transactionErrors } = useTransaction()
 
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContract] = React.useState({
     send: new Contract(address, ERC20ABI, readProvider),
@@ -135,12 +140,13 @@ const useERC20 = (address: string, rpcURL = networks[137].rpc) => {
     }
 
     signContranct()
-  }, [address, rpcURL, wallet])
+  }, [address, chainId, wallet])
 
   return React.useMemo(() => {
     return ERC20Contract(contract, txNotification, transactionErrors)
   }, [contract])
 }
+
 type ParamsType = {
   wallet: WalletState | null
   txNotification: (
@@ -157,10 +163,15 @@ type ParamsType = {
 
 export const ERC20 = async (
   address: string,
-  rpcUrl = networks[137].rpc,
+  chainId = 137,
   params?: ParamsType
 ) => {
-  const readProvider = new JsonRpcProvider(rpcUrl)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
+
   const contract: ContractType = {
     read: new Contract(address, ERC20ABI, readProvider),
     send: new Contract(address, ERC20ABI, readProvider)

--- a/src/hooks/useGasFee.tsx
+++ b/src/hooks/useGasFee.tsx
@@ -1,11 +1,14 @@
-import { JsonRpcProvider, formatUnits } from 'ethers'
+import { JsonRpcProvider, Network, formatUnits } from 'ethers'
 
 import { networks } from '@/constants/tokenAddresses'
 import Big from 'big.js'
 
 const useGasFee = (networkId: number) => {
-  const rpcURL = networks[networkId || 137].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[networkId || 137]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const gasFee = async (number: number) => {
     const estimateGasUsed = Big(number)

--- a/src/hooks/useGov.tsx
+++ b/src/hooks/useGov.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useConnectWallet } from '@web3-onboard/react'
-import { BrowserProvider, JsonRpcProvider, Contract } from 'ethers'
+import { BrowserProvider, JsonRpcProvider, Contract, Network } from 'ethers'
 
 import Governance from '@/constants/abi/Governance.json'
 import { networks } from '@/constants/tokenAddresses'
@@ -32,12 +32,15 @@ const valuesStateProposal: Array<StateProposal> = [
   ['Succeeded', 'Executed', executed, '7']
 ]
 
-const useGov = (address: string) => {
+const useGov = (address: string, chainId = 43114) => {
   const [{ wallet }] = useConnectWallet()
   const { txNotification, transactionErrors } = useTransaction()
 
-  const rpcURL = networks[43114].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContract] = React.useState({
     send: new Contract(address, Governance, readProvider),

--- a/src/hooks/usePoolContract.tsx
+++ b/src/hooks/usePoolContract.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Contract, JsonRpcProvider } from 'ethers'
+import { Contract, JsonRpcProvider, Network } from 'ethers'
 
 import Pool from '../constants/abi/Pool.json'
 
@@ -165,8 +165,11 @@ function PoolContract(contract: Contract) {
 }
 
 const usePoolContract = (address: string, chainId = 43114) => {
-  const rpcURL = networks[chainId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContract] = React.useState(
     new Contract(address, Pool, readProvider)
@@ -182,8 +185,11 @@ const usePoolContract = (address: string, chainId = 43114) => {
 }
 
 export const corePoolContract = (address: string, chainId = 43114) => {
-  const rpcURL = networks[chainId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
   const contract = new Contract(address, Pool, readProvider)
 
   return PoolContract(contract)

--- a/src/hooks/usePriceLPEthers.tsx
+++ b/src/hooks/usePriceLPEthers.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Contract, JsonRpcProvider } from 'ethers'
+import { Contract, JsonRpcProvider, Network } from 'ethers'
 import Big from 'big.js'
 
 import { lpPoolType } from '@/constants/pools'
@@ -23,7 +23,11 @@ const usePriceLP = () => {
     const getReservesAvax = async (address: string, chainId: number) => {
       let value
       try {
-        const provider = new JsonRpcProvider(networks[chainId].rpc)
+        const networkInfo = networks[chainId]
+        const network = new Network(networkInfo.chainName, networkInfo.chainId)
+        const provider = new JsonRpcProvider(networkInfo.rpc, network, {
+          staticNetwork: network
+        })
         const contract = new Contract(address, PriceLP.abi, provider)
         const response = await contract.getReserves()
 
@@ -44,9 +48,12 @@ const usePriceLP = () => {
 
       let value
       try {
-        const network = networks[chainId]
-        const provider = new JsonRpcProvider(network.rpc)
-        const vault = new Contract(network.vault, VAULT, provider)
+        const networkInfo = networks[chainId]
+        const network = new Network(networkInfo.chainName, networkInfo.chainId)
+        const provider = new JsonRpcProvider(networkInfo.rpc, network, {
+          staticNetwork: network
+        })
+        const vault = new Contract(networkInfo.vault, VAULT, provider)
         const res = await vault.getPoolTokenInfo(
           balancerPoolId,
           tokenPoolAddress
@@ -75,7 +82,7 @@ const usePriceLP = () => {
 
       const totalReserveValueInDollars = Big(reserveValue).mul(tokenPoolPrice)
 
-      const ERC20Contract = await ERC20(poolAddress, networks[chainId].rpc)
+      const ERC20Contract = await ERC20(poolAddress, chainId)
       const supplyLPToken = await ERC20Contract.totalSupply()
 
       return totalReserveValueInDollars

--- a/src/hooks/usePrivateInvestors.tsx
+++ b/src/hooks/usePrivateInvestors.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
-import { JsonRpcProvider, Contract } from 'ethers'
+import { JsonRpcProvider, Contract, Network } from 'ethers'
 
 import PrivateInvestors from '@/constants/abi/PrivateInvestors.json'
 import { networks } from '@/constants/tokenAddresses'
 
 const usePrivateInvestors = (contractAddress: string, chainId = 137) => {
   // Set read rpc
-  const rpcURL = networks[chainId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContract] = React.useState(
     new Contract(contractAddress, PrivateInvestors, readProvider)

--- a/src/hooks/useStaking.tsx
+++ b/src/hooks/useStaking.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import Big from 'big.js'
 
-import { BrowserProvider, JsonRpcProvider, Contract, ZeroAddress } from 'ethers'
+import {
+  BrowserProvider,
+  JsonRpcProvider,
+  Contract,
+  ZeroAddress,
+  Network
+} from 'ethers'
 import { useConnectWallet } from '@web3-onboard/react'
 
 import { networks } from '@/constants/tokenAddresses'
@@ -29,8 +35,11 @@ const useStaking = (address: string, chainId = 43114) => {
   const [{ wallet }] = useConnectWallet()
   const { txNotification, transactionErrors } = useTransaction()
 
-  const rpcURL = networks[chainId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContractEthers] = React.useState({
     send: new Contract(address, StakingContract, readProvider),
@@ -61,8 +70,12 @@ const useStaking = (address: string, chainId = 43114) => {
       address: string,
       chainId: number
     ) => {
-      const provider = new JsonRpcProvider(networks[chainId].rpc)
-      const infoContract = new Contract(address, StakingContract, provider)
+      const networkInfo = networks[chainId]
+      const network = new Network(networkInfo.chainName, networkInfo.chainId)
+      const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+        staticNetwork: network
+      })
+      const infoContract = new Contract(address, StakingContract, readProvider)
       const value = await infoContract.userInfo(pid, walletAddress)
       return value
     }
@@ -128,8 +141,12 @@ const useStaking = (address: string, chainId = 43114) => {
       address: string,
       chainId: number
     ) => {
-      const provider = new JsonRpcProvider(networks[chainId].rpc)
-      const infoContract = new Contract(address, StakingContract, provider)
+      const networkInfo = networks[chainId]
+      const network = new Network(networkInfo.chainName, networkInfo.chainId)
+      const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+        staticNetwork: network
+      })
+      const infoContract = new Contract(address, StakingContract, readProvider)
       const value: bigint = await infoContract.earned(pid, walletAddress)
       return value
     }

--- a/src/hooks/useStakingInfo.tsx
+++ b/src/hooks/useStakingInfo.tsx
@@ -39,7 +39,7 @@ const useStakingInfo = (chaindId: number, pid?: number) => {
   }
 
   async function handleApprove(stakingToken: string, poolSymbol: string) {
-    const erc20 = await ERC20(stakingToken, networkChain.rpc, {
+    const erc20 = await ERC20(stakingToken, chaindId, {
       transactionErrors: transaction.transactionErrors,
       txNotification: transaction.txNotification,
       wallet: wallet
@@ -67,7 +67,7 @@ const useStakingInfo = (chaindId: number, pid?: number) => {
 
   async function getPoolInfo(pid: number, kacyPrice: Big, poolPrice: Big) {
     const poolInfoRes = await staking.poolInfo(pid)
-    const erc20 = await ERC20(poolInfoRes.stakingToken, networkChain.rpc)
+    const erc20 = await ERC20(poolInfoRes.stakingToken, chaindId)
     const decimals = await erc20.decimals()
 
     const totalStaked = Big(poolInfoRes.depositedAmount.toString())

--- a/src/hooks/useVotings.tsx
+++ b/src/hooks/useVotings.tsx
@@ -1,20 +1,23 @@
 import React from 'react'
 import { useConnectWallet } from '@web3-onboard/react'
-import { BrowserProvider, JsonRpcProvider, Contract } from 'ethers'
+import { BrowserProvider, JsonRpcProvider, Contract, Network } from 'ethers'
 
 import useTransaction from './useTransaction'
 
 import StakingContract from '../constants/abi/Staking.json'
 import { networks } from '@/constants/tokenAddresses'
 
-const useVotingPower = (address: string) => {
+const useVotingPower = (address: string, chainId = 43114) => {
   // Get user wallet
   const [{ wallet }] = useConnectWallet()
   const { txNotification, transactionErrors } = useTransaction()
 
   // Set read rpc
-  const rpcURL = networks[43114].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
+  const networkInfo = networks[chainId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
 
   const [contract, setContract] = React.useState({
     send: new Contract(address, StakingContract, readProvider),

--- a/src/hooks/useWhiteList.tsx
+++ b/src/hooks/useWhiteList.tsx
@@ -1,12 +1,14 @@
-import { JsonRpcProvider, Contract } from 'ethers'
+import { JsonRpcProvider, Contract, Network } from 'ethers'
 
 import { networks } from '@/constants/tokenAddresses'
 import KassandraWhitelistAbi from '@/constants/abi/KassandraWhitelist.json'
 
 const useWhiteList = (networkId: number) => {
-  const rpcURL = networks[networkId].rpc
-  const readProvider = new JsonRpcProvider(rpcURL)
-
+  const networkInfo = networks[networkId]
+  const network = new Network(networkInfo.chainName, networkInfo.chainId)
+  const readProvider = new JsonRpcProvider(networkInfo.rpc, network, {
+    staticNetwork: network
+  })
   const read = new Contract(
     networks[networkId].whiteList,
     KassandraWhitelistAbi,

--- a/src/store/reducers/modalAlertText.ts
+++ b/src/store/reducers/modalAlertText.ts
@@ -23,6 +23,7 @@ export const modalAlertTextSlice = createSlice({
     removeModalAlertText: state => {
       state.errorText = null
       state.solutionText = null
+      state.transactionData = null
     }
   }
 })

--- a/src/templates/Manage/CreatePool/index.tsx
+++ b/src/templates/Manage/CreatePool/index.tsx
@@ -137,7 +137,7 @@ const CreatePool = ({ setIsCreatePool }: ICreatePoolProps) => {
     for (const token of tokens) {
       const { allowance } = await ERC20(
         token.address,
-        networks[poolData.networkId ?? 137].rpc,
+        poolData.networkId ?? 137,
         {
           wallet: null,
           txNotification: txNotification,
@@ -285,7 +285,7 @@ const CreatePool = ({ setIsCreatePool }: ICreatePoolProps) => {
     for (const token of notAprovedTokens) {
       const { approve, allowance } = await ERC20(
         token.address,
-        networks[poolData.networkId ?? 137].rpc,
+        poolData.networkId ?? 137,
         {
           wallet: wallet,
           txNotification: txNotification,

--- a/src/templates/Pool/MyAsset/index.tsx
+++ b/src/templates/Pool/MyAsset/index.tsx
@@ -74,7 +74,7 @@ const MyAsset = ({
     chainInfo.stakingContract ?? ethers.ZeroAddress,
     chainInfo.chainId
   )
-  const ERC20 = useERC20(poolToken, networks[chainInfo.chainId].rpc)
+  const ERC20 = useERC20(poolToken, chainInfo.chainId)
   const { trackEventFunction } = useMatomoEcommerce()
   const { data } = useTokensData({
     chainId: networks[137].chainId,

--- a/src/templates/PoolManager/ManageAssets/AddLiquidity/AddLiquidityOperation/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/AddLiquidity/AddLiquidityOperation/index.tsx
@@ -114,7 +114,7 @@ const AddLiquidityOperation = () => {
 
       const { balance } = await ERC20(
         token,
-        networks[(poolInfo && poolInfo[0]?.chain_id) ?? 137].rpc
+        (poolInfo && poolInfo[0]?.chain_id) ?? 137
       )
       const balanceValue = await balance(wallet.accounts[0].address)
       setUserBalance(Big(balanceValue))

--- a/src/templates/PoolManager/ManageAssets/TokenRemoval/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/TokenRemoval/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useRouter } from 'next/router'
 import Big from 'big.js'
 import { useConnectWallet } from '@web3-onboard/react'
+import { ZeroAddress } from 'ethers'
 
 import { mockTokens, networks } from '@/constants/tokenAddresses'
 
@@ -42,8 +43,8 @@ const TokenRemoval = () => {
     id: poolId
   })
   const { balance } = useERC20(
-    (poolInfo && poolInfo[0]?.address) ?? '',
-    networks[(poolInfo && poolInfo[0]?.chain_id) ?? 137].rpc
+    (poolInfo && poolInfo[0]?.address) ?? ZeroAddress,
+    (poolInfo && poolInfo[0]?.chain_id) ?? 137
   )
 
   const { data } = useTokensData({

--- a/src/templates/PoolManager/ManageAssets/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/index.tsx
@@ -300,7 +300,7 @@ const ManageAssets = ({ setIsOpenManageAssets }: IManageAssetsProps) => {
 
     const { allowance } = await ERC20(
       tokenId,
-      networks[(poolInfo && poolInfo[0]?.chain_id) ?? 137].rpc,
+      (poolInfo && poolInfo[0]?.chain_id) ?? 137,
       {
         wallet: null,
         txNotification: txNotification,
@@ -599,7 +599,7 @@ const ManageAssets = ({ setIsOpenManageAssets }: IManageAssetsProps) => {
 
     const { approve, allowance } = await ERC20(
       token.address,
-      networks[poolInfo[0]?.chain_id ?? 137].rpc,
+      poolInfo[0]?.chain_id ?? 137,
       {
         wallet: wallet,
         txNotification: txNotification,

--- a/src/templates/PoolV2/Hero/MyAsset/index.tsx
+++ b/src/templates/PoolV2/Hero/MyAsset/index.tsx
@@ -58,10 +58,7 @@ const MyAsset = ({
   async function getBalance(decimals: number): Promise<void> {
     if (!wallet) return
 
-    const { balance } = await ERC20(
-      poolAddress,
-      networks[chainInfo.chainId].rpc
-    )
+    const { balance } = await ERC20(poolAddress, chainInfo.chainId)
 
     const balanceToken = Big(await balance(wallet.accounts[0].address))
 

--- a/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/Invest/index.tsx
@@ -6,7 +6,7 @@ import { useConnectWallet, useSetChain } from '@web3-onboard/react'
 import { ZeroAddress, isAddress } from 'ethers'
 
 import { usePoolInfo } from '@/hooks/query/usePoolInfo'
-import { NATIVE_ADDRESS, networks } from '@/constants/tokenAddresses'
+import { NATIVE_ADDRESS } from '@/constants/tokenAddresses'
 import { usePoolData } from '@/hooks/query/usePoolData'
 import { useReferralDecrypt } from '@/hooks/query/useReferralDecrypt'
 
@@ -290,10 +290,7 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
     if (!wallet?.provider || !tokenSelect.address) return
     let value: string
     try {
-      const { allowance } = await ERC20(
-        tokenSelect.address,
-        networks[chainId].rpc
-      )
+      const { allowance } = await ERC20(tokenSelect.address, chainId)
 
       const allowanceValue = await allowance(
         operation.contractAddress,
@@ -323,10 +320,7 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
   async function handleApproveSuccess() {
     if (!wallet) return
 
-    const { allowance } = await ERC20(
-      tokenSelect.address,
-      networks[chainId].rpc
-    )
+    const { allowance } = await ERC20(tokenSelect.address, chainId)
 
     let approved = false
     while (!approved) {
@@ -387,10 +381,7 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
         : undefined
     )
 
-    const { allowance } = await ERC20(
-      tokenSelect.address,
-      networks[chainId].rpc
-    )
+    const { allowance } = await ERC20(tokenSelect.address, chainId)
     const allowanceValue = await allowance(
       operation.contractAddress,
       wallet.accounts[0].address
@@ -442,15 +433,11 @@ const Invest = ({ typeAction, privateInvestors }: IInvestProps) => {
         approvals[typeAction][0] === 0 &&
         tokenSelect.address !== NATIVE_ADDRESS
       ) {
-        const { approve } = await ERC20(
-          tokenSelect.address,
-          networks[chainId].rpc,
-          {
-            wallet: wallet,
-            txNotification: txNotification,
-            transactionErrors: transactionErrors
-          }
-        )
+        const { approve } = await ERC20(tokenSelect.address, chainId, {
+          wallet: wallet,
+          txNotification: txNotification,
+          transactionErrors: transactionErrors
+        })
         approve(
           operation.contractAddress,
           {

--- a/src/templates/PoolV2/NewPoolOperations/Form/Withdraw/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/Withdraw/index.tsx
@@ -132,10 +132,7 @@ const Withdraw = ({ typeWithdraw, typeAction }: IWithdrawProps) => {
     let approved = false
     while (!approved) {
       await new Promise(r => setTimeout(r, 1000)) // sleep
-      const { allowance } = await ERC20(
-        pool?.address || '',
-        networks[chainId].rpc
-      )
+      const { allowance } = await ERC20(pool?.address || '', chainId)
       const allowanceValue = await allowance(
         proxyInvest,
         wallet.accounts[0].address
@@ -225,15 +222,11 @@ const Withdraw = ({ typeWithdraw, typeAction }: IWithdrawProps) => {
       )
 
       if (approvals[typeAction][0] === 0) {
-        const { approve } = await ERC20(
-          pool?.address ?? '',
-          networks[chainId].rpc,
-          {
-            wallet: wallet,
-            txNotification: txNotification,
-            transactionErrors: transactionErrors
-          }
-        )
+        const { approve } = await ERC20(pool?.address ?? '', chainId, {
+          wallet: wallet,
+          txNotification: txNotification,
+          transactionErrors: transactionErrors
+        })
 
         approve(
           proxyInvest,
@@ -356,10 +349,7 @@ const Withdraw = ({ typeWithdraw, typeAction }: IWithdrawProps) => {
   async function updateAllowance() {
     if (!wallet) return
 
-    const { allowance } = await ERC20(
-      pool?.address || '',
-      networks[pool?.chain_id || '0'].rpc
-    )
+    const { allowance } = await ERC20(pool?.address || '', pool?.chain_id || 0)
     const allowanceValue = await allowance(
       proxyInvest,
       wallet.accounts[0].address

--- a/src/templates/PoolV2/NewPoolOperations/Form/index.tsx
+++ b/src/templates/PoolV2/NewPoolOperations/Form/index.tsx
@@ -4,7 +4,7 @@ import { useConnectWallet } from '@web3-onboard/react'
 import { BrowserProvider, ethers, JsonRpcSigner } from 'ethers'
 
 import { OperationProvider } from './PoolOperationContext'
-import { useAppSelector } from '@/store/hooks'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import usePrivateInvestors from '@/hooks/usePrivateInvestors'
 import { usePoolData } from '@/hooks/query/usePoolData'
 import useGetToken from '@/hooks/useGetToken'
@@ -24,6 +24,7 @@ import useERC20 from '@/hooks/useERC20'
 import { useTokensData } from '@/hooks/query/useTokensData'
 
 import * as S from './styles'
+import { setModalAlertText } from '@/store/reducers/modalAlertText'
 
 export type Titles = keyof typeof messages
 
@@ -40,6 +41,7 @@ interface IFormProps {
 const Form = ({ typeAction, typeWithdraw }: IFormProps) => {
   const [privateInvestors, setPrivateInvestors] = React.useState<string[]>([])
   const [signerProvider, setsignerProvider] = React.useState<JsonRpcSigner>()
+  const dispatch = useAppDispatch()
 
   const [{ wallet }] = useConnectWallet()
   const router = useRouter()
@@ -48,7 +50,7 @@ const Form = ({ typeAction, typeWithdraw }: IFormProps) => {
   const network = networks[pool?.chain_id || 137]
 
   const { tokenListSwapProvider } = useAppSelector(state => state)
-  const ERC20 = useERC20(pool?.address || ethers.ZeroAddress, network.rpc)
+  const ERC20 = useERC20(pool?.address || ethers.ZeroAddress, network.chainId)
   const { privateAddresses } = usePrivateInvestors(
     network.privateInvestor,
     pool?.chain_id
@@ -81,7 +83,11 @@ const Form = ({ typeAction, typeWithdraw }: IFormProps) => {
 
     const provider = new BrowserProvider(wallet?.provider)
     const signer = await provider.getSigner()
+    // const tt = await provider.getNetwork()
+    // const gg = await signer.provider.getRpcRequest()
 
+    // console.log('tt', tt)
+    // console.log('gg', gg)
     setsignerProvider(signer)
   }
 
@@ -127,6 +133,7 @@ const Form = ({ typeAction, typeWithdraw }: IFormProps) => {
         {typeAction === 'Invest' && (
           <Invest typeAction="Invest" privateInvestors={privateInvestors} />
         )}
+
         {typeAction === 'Withdraw' && (
           <Withdraw typeWithdraw={typeWithdraw} typeAction="Withdraw" />
         )}

--- a/src/templates/PoolV2/Staking/PoolStakingCard/index.tsx
+++ b/src/templates/PoolV2/Staking/PoolStakingCard/index.tsx
@@ -85,7 +85,7 @@ const PoolStakingCard = ({
   }
 
   async function updateAllowance() {
-    const erc20 = await ERC20(poolInfo.stakingToken, networkChain.rpc)
+    const erc20 = await ERC20(poolInfo.stakingToken, networkChain.chainId)
 
     const allowance = await erc20.allowance(
       networkChain.stakingContract ?? ethers.ZeroAddress,

--- a/src/templates/Profile/index.tsx
+++ b/src/templates/Profile/index.tsx
@@ -172,7 +172,7 @@ const Profile = () => {
     const valueInWallet: IAssetsValueWalletProps = {}
     for (const id of ids) {
       try {
-        const ERC20Contract = await ERC20(id, chain.rpc)
+        const ERC20Contract = await ERC20(id, chain.chainId)
         const balanceToken = await ERC20Contract.balance(walletUserString)
 
         Object.assign(valueInWallet, {

--- a/src/utils/poolUtils.ts
+++ b/src/utils/poolUtils.ts
@@ -126,7 +126,7 @@ export const getBalanceToken = async (
     return Big(balanceToken.toString())
   }
 
-  const { balance } = await ERC20(address, networks[chainId].rpc)
+  const { balance } = await ERC20(address, chainId)
   const balanceToken = await balance(userWalletAddress).then(newBalance =>
     Big(newBalance.toString())
   )


### PR DESCRIPTION
## Why

This update addresses an issue where the Ethers lib continued attempting to reconnect to the RPC even after receiving the 429 error. With this fix, the library will no longer be stuck in this reconnection loop.
