### PR TITLE
feat: stake list view

### DIFF
--- a/public/assets/icons/circle-right-arrow.svg
+++ b/public/assets/icons/circle-right-arrow.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15Z" stroke="#FCFCFC" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 10.8002L10.8 8.0002L8 5.2002" stroke="#FCFCFC" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.2002 8H10.8002" stroke="#FCFCFC" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -13,6 +13,7 @@ export type IbackgroundVoteProps = {
 }
 
 export type ButtonProps = {
+  rightIcon?: boolean
   text?: string
   as?: React.ElementType
   size?: ISizeProps
@@ -37,6 +38,7 @@ const ButtonBase: React.ForwardRefRenderFunction<
     fullWidth = false,
     disabledNoEvent = false,
     text,
+    rightIcon,
     image = '',
     ...props
   },
@@ -54,14 +56,29 @@ const ButtonBase: React.ForwardRefRenderFunction<
       ref={ref}
       {...props}
     >
-      {image.length > 0 ? (
-        <S.ImgWrapper>
-          <img src={image} alt="User image" width={18} height={18} />
-        </S.ImgWrapper>
+      {!rightIcon ? (
+        <>
+          {image.length > 0 ? (
+            <S.ImgWrapper>
+              <img src={image} alt="User image" width={18} height={18} />
+            </S.ImgWrapper>
+          ) : (
+            icon
+          )}
+          {text}
+        </>
       ) : (
-        icon
+        <>
+          {text}
+          {image.length > 0 ? (
+            <S.ImgWrapper>
+              <img src={image} alt="User image" width={18} height={18} />
+            </S.ImgWrapper>
+          ) : (
+            icon
+          )}
+        </>
       )}
-      {text}
     </S.Wrapper>
   )
 }

--- a/src/components/DepositFee/index.tsx
+++ b/src/components/DepositFee/index.tsx
@@ -47,8 +47,8 @@ const DepositFee = ({
         />
       </S.DepositFeeHeader>
       <S.CardWrapperParagraph>
-        Receive a percentage of each new deposit in the pool at the selected
-        address.
+        Receive a percentage of each new deposit in the portfolio at the
+        selected address.
       </S.CardWrapperParagraph>
       {feesData?.depositFee && (
         <S.FeeContainer isFeeChecked={feesData.depositFee.isChecked}>

--- a/src/components/NewSelectTabs/ViewOptions/styles.ts
+++ b/src/components/NewSelectTabs/ViewOptions/styles.ts
@@ -5,6 +5,13 @@ export const ViewIcons = styled.div`
   display: flex;
   align-items: center;
   gap: 1.6rem;
+
+  border: 1px solid #fcfcfc26;
+  border-radius: 0.8rem;
+  background: #fcfcfc0d;
+  padding-inline: 1rem;
+
+  width: fit-content;
 `
 
 interface ViewButtonProps {
@@ -14,9 +21,9 @@ interface ViewButtonProps {
 
 export const ViewButton = styled(Button)<ViewButtonProps>`
   background-color: transparent;
-  padding: 0;
 
   cursor: ${props => (props.myPoolsSelected ? 'not-allowed' : 'pointer')};
+  padding: 0;
 
   svg {
     height: 2rem;
@@ -25,7 +32,7 @@ export const ViewButton = styled(Button)<ViewButtonProps>`
       fill: ${props =>
         props.isActive && !props.myPoolsSelected ? '#26DBDB' : null};
       fill-opacity: ${props =>
-        props.isActive && !props.myPoolsSelected ? '1' : '0.08'};
+        props.isActive && !props.myPoolsSelected ? '1' : '0.25'};
     }
   }
 `

--- a/src/components/NewSelectTabs/ViewOptions/styles.ts
+++ b/src/components/NewSelectTabs/ViewOptions/styles.ts
@@ -6,11 +6,6 @@ export const ViewIcons = styled.div`
   align-items: center;
   gap: 1.6rem;
 
-  border: 1px solid #fcfcfc26;
-  border-radius: 0.8rem;
-  background: #fcfcfc0d;
-  padding-inline: 1rem;
-
   width: fit-content;
 `
 
@@ -21,13 +16,14 @@ interface ViewButtonProps {
 
 export const ViewButton = styled(Button)<ViewButtonProps>`
   background-color: transparent;
+  display: flex;
 
   cursor: ${props => (props.myPoolsSelected ? 'not-allowed' : 'pointer')};
   padding: 0;
 
   svg {
-    height: 2rem;
-    width: 2rem;
+    height: 2.4rem;
+    width: 2.4rem;
     path {
       fill: ${props =>
         props.isActive && !props.myPoolsSelected ? '#26DBDB' : null};

--- a/src/templates/Explore/AllPools/index.tsx
+++ b/src/templates/Explore/AllPools/index.tsx
@@ -10,11 +10,7 @@ import {
 import { VERSION_POOL_CREATE } from '@/constants/tokenAddresses'
 import CreatePool from '@/templates/Manage/CreatePool'
 
-interface ExploreAllPools {
-  numberOfPools: string
-}
-
-export function ExploreAllPools({ numberOfPools }: ExploreAllPools) {
+export function ExploreAllPools() {
   const [isCreatePool, setIsCreatePool] = React.useState(false)
   const dispatch = useAppDispatch()
 
@@ -43,12 +39,11 @@ export function ExploreAllPools({ numberOfPools }: ExploreAllPools) {
         <S.TextContent>
           Din't find what you were looking for?
           <span>Why not create your own?</span>
-          {/* <S.PoolsNumber>({numberOfPools})</S.PoolsNumber> */}
         </S.TextContent>
         <Button
           background="primary"
           size="huge"
-          text="Create Your Pool"
+          text="Create Your Portfolio"
           className="button"
           onClick={handleCreatePool}
         />

--- a/src/templates/Explore/AllPools/index.tsx
+++ b/src/templates/Explore/AllPools/index.tsx
@@ -41,12 +41,14 @@ export function ExploreAllPools({ numberOfPools }: ExploreAllPools) {
     <S.AllPoolsWrapper>
       <S.Content>
         <S.TextContent>
-          All Pools <S.PoolsNumber>({numberOfPools})</S.PoolsNumber>
+          Din't find what you were looking for?
+          <span>Why not create your own?</span>
+          {/* <S.PoolsNumber>({numberOfPools})</S.PoolsNumber> */}
         </S.TextContent>
         <Button
-          background="secondary"
-          size="large"
-          text="Create Pool"
+          background="primary"
+          size="huge"
+          text="Create Your Pool"
           className="button"
           onClick={handleCreatePool}
         />

--- a/src/templates/Explore/AllPools/styles.ts
+++ b/src/templates/Explore/AllPools/styles.ts
@@ -23,6 +23,10 @@ export const Content = styled.div`
     width: 25rem;
     white-space: nowrap;
   }
+
+  @media (max-width: 960px) {
+    flex-direction: column;
+  }
 `
 
 export const TextContent = styled.p`
@@ -36,6 +40,11 @@ export const TextContent = styled.p`
     display: block;
     opacity: 0.75;
     font-size: 1.4rem;
+  }
+
+  @media (max-width: 560px) {
+    font-size: 1.8rem;
+    line-height: 2.4rem;
   }
 `
 

--- a/src/templates/Explore/AllPools/styles.ts
+++ b/src/templates/Explore/AllPools/styles.ts
@@ -12,13 +12,15 @@ export const Content = styled.div`
   padding: 2.4rem;
   background: rgba(252, 252, 252, 0.05);
 
+  margin-top: 3.2rem;
+
   .button {
     font-family: Rubik;
-    font-size: 1.4rem;
+    font-size: 1.8rem;
     font-weight: 500;
     line-height: 1.4rem;
     color: #fcfcfc;
-    width: 15.4rem;
+    width: 25rem;
     white-space: nowrap;
   }
 `
@@ -29,6 +31,12 @@ export const TextContent = styled.p`
   font-weight: 500;
   line-height: 3.2rem;
   white-space: nowrap;
+
+  span {
+    display: block;
+    opacity: 0.75;
+    font-size: 1.4rem;
+  }
 `
 
 export const PoolsNumber = styled.span`

--- a/src/templates/Explore/ManagersPoolTable/index.tsx
+++ b/src/templates/Explore/ManagersPoolTable/index.tsx
@@ -265,7 +265,7 @@ const ManagersPoolTable = () => {
             return (
               <TR key={manager.address}>
                 <Link
-                  href={`/profile/${manager.address}?tab=managed-pools`}
+                  href={`/profile/${manager.address}?tab=managed-portfolios`}
                   passHref
                 >
                   <TRLink>
@@ -281,7 +281,7 @@ const ManagersPoolTable = () => {
                         image={manager.image}
                         hasAddress={true}
                         isLink={false}
-                        tab="?tab=managed-pools"
+                        tab="?tab=managed-portfolios"
                       />
                     </TD>
                     <TD isView={inViewCollum === 1}>

--- a/src/templates/Explore/PoolsData/index.tsx
+++ b/src/templates/Explore/PoolsData/index.tsx
@@ -16,7 +16,7 @@ export function ExplorePoolsData({
   const poolsData = [
     {
       icon: <img src="/assets/icons/pie.svg" alt="an icon of a chart pie" />,
-      name: 'Pools',
+      name: 'Portfolios',
       amount: poolCount
     },
     {

--- a/src/templates/Explore/PoolsData/index.tsx
+++ b/src/templates/Explore/PoolsData/index.tsx
@@ -41,7 +41,7 @@ export function ExplorePoolsData({
     },
     {
       icon: <img src="/assets/icons/wallet.svg" alt="an icon of a wallet" />,
-      name: 'Depositors',
+      name: 'Investors',
       amount: numDeposits
     }
   ]

--- a/src/templates/Explore/PoolsData/index.tsx
+++ b/src/templates/Explore/PoolsData/index.tsx
@@ -16,7 +16,7 @@ export function ExplorePoolsData({
   const poolsData = [
     {
       icon: <img src="/assets/icons/pie.svg" alt="an icon of a chart pie" />,
-      name: 'Number of Pools',
+      name: 'Pools',
       amount: poolCount
     },
     {
@@ -36,12 +36,12 @@ export function ExplorePoolsData({
           alt="an icon of person inside a circle"
         />
       ),
-      name: 'Number of Managers',
+      name: 'Managers',
       amount: numManagers
     },
     {
       icon: <img src="/assets/icons/wallet.svg" alt="an icon of a wallet" />,
-      name: 'Number of Depositors',
+      name: 'Depositors',
       amount: numDeposits
     }
   ]

--- a/src/templates/Explore/SelectTabs/icons.tsx
+++ b/src/templates/Explore/SelectTabs/icons.tsx
@@ -2,7 +2,7 @@ export const listViewIcon = (
   <svg
     width="20"
     height="20"
-    viewBox="0 0 20 20"
+    viewBox="0 0 20 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
@@ -18,7 +18,7 @@ export const gridviewIcon = (
   <svg
     width="20"
     height="20"
-    viewBox="0 0 20 20"
+    viewBox="0 0 20 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/src/templates/Explore/SelectTabs/index.tsx
+++ b/src/templates/Explore/SelectTabs/index.tsx
@@ -1,6 +1,4 @@
 import * as S from './styles'
-import { useRouter } from 'next/router'
-import { ViewOptions } from '@/components/NewSelectTabs/ViewOptions'
 
 type ChainList = {
   name: string
@@ -28,11 +26,11 @@ const tabs = [
   },
   {
     tabName: 'allPools',
-    text: 'All Pools'
+    text: 'All Portfolios'
   },
   {
     tabName: 'myPools',
-    text: 'My Pools'
+    text: 'My Investments'
   }
 ]
 

--- a/src/templates/Explore/SelectTabs/index.tsx
+++ b/src/templates/Explore/SelectTabs/index.tsx
@@ -23,6 +23,10 @@ interface ExploreSelectTabsProps {
 
 const tabs = [
   {
+    tabName: 'discover',
+    text: 'Discover'
+  },
+  {
     tabName: 'allPools',
     text: 'All Pools'
   },
@@ -88,11 +92,11 @@ export function ExploreSelectTabs({
       </S.MobileTabs>
       <S.Content>
         <S.LeftContent>
-          <ViewOptions
+          {/* <ViewOptions
             isSelect={isSelect}
             selectedView={selectedView}
             setSelectedView={setSelectedView}
-          />
+          /> */}
 
           <S.DesktopTabs>
             {tabs.map(tab => (

--- a/src/templates/Explore/SelectTabs/styles.ts
+++ b/src/templates/Explore/SelectTabs/styles.ts
@@ -87,6 +87,7 @@ export const TabButton = styled(Button)<TabButtonProps>`
     props.isActiveTab ? '#FCFCFC0D' : 'transparent'};
 
   @media (max-width: 768px) {
+    font-size: 1.4rem;
     width: 100%;
     border: ${props =>
       props.isActiveTab

--- a/src/templates/Explore/index.tsx
+++ b/src/templates/Explore/index.tsx
@@ -94,7 +94,7 @@ export default function Explore() {
   const [totalPoolsTable, setTotalPoolsTable] = React.useState(0)
   const [skip, setSkip] = React.useState(0)
 
-  const take = 8
+  const take = 10
 
   const { data: communityPools } = useCommunityPools({
     day: Math.trunc(Date.now() / 1000 - 60 * 60 * 24),

--- a/src/templates/Explore/index.tsx
+++ b/src/templates/Explore/index.tsx
@@ -17,8 +17,6 @@ import TitleSection from '../../components/TitleSection'
 
 import featuredFunds from '../../../public/assets/iconGradient/featured.svg'
 import ShareEarnIcon from '@assets/icons/handshake.svg'
-// import managerIcon from '../../../public/assets/iconGradient/manager.svg'
-// import inexpensiveIcon from '../../../public/assets/iconGradient/inexpensive.svg'
 
 import * as S from './styles'
 import NewCommunityPoolsTable, {
@@ -122,7 +120,7 @@ export default function Explore() {
   return (
     <S.Explore>
       <S.TitleContainer>
-        <S.MainTitle>Explore All Pools</S.MainTitle>
+        <S.MainTitle>Explore All Portfolios</S.MainTitle>
         <S.SubTitle>Find a strategy that fits your needs</S.SubTitle>
       </S.TitleContainer>
 
@@ -153,7 +151,11 @@ export default function Explore() {
       {isSelectTab === 'discover' && (
         <div>
           <S.ExploreContainer>
-            <TitleSection image={featuredFunds} title="Popular Pools" text="" />
+            <TitleSection
+              image={featuredFunds}
+              title="Popular Portfolios"
+              text=""
+            />
 
             <SliderPoolList
               poolData={poolsKassandra?.poolsKassandra ?? new Array(9).fill({})}
@@ -170,8 +172,14 @@ export default function Explore() {
             />
           </S.ExploreContainer>
 
+          <ExploreAllPools />
+
           <S.ExploreContainer>
-            <TitleSection image={featuredFunds} title="Largest Pools" text="" />
+            <TitleSection
+              image={featuredFunds}
+              title="Largest Portfolios"
+              text=""
+            />
 
             <SliderPoolList
               poolData={largestPools?.pools ?? new Array(9).fill({})}
@@ -207,10 +215,6 @@ export default function Explore() {
           </S.PaginationWrapper>
         </>
       )}
-
-      <ExploreAllPools
-        numberOfPools={poolsData ? poolsData[0].pool_count.toString() : '0'}
-      />
     </S.Explore>
   )
 }

--- a/src/templates/Explore/index.tsx
+++ b/src/templates/Explore/index.tsx
@@ -54,7 +54,7 @@ export default function Explore() {
     chainList.map(item => item.chainId)
   )
   const [isSelectTab, setIsSelectTab] = useState<string | string[] | undefined>(
-    'allPools'
+    'discover'
   )
 
   const networkChain = networks[137]
@@ -94,7 +94,7 @@ export default function Explore() {
   const [totalPoolsTable, setTotalPoolsTable] = React.useState(0)
   const [skip, setSkip] = React.useState(0)
 
-  const take = 10
+  const take = 20
 
   const { data: communityPools } = useCommunityPools({
     day: Math.trunc(Date.now() / 1000 - 60 * 60 * 24),
@@ -135,10 +135,6 @@ export default function Explore() {
             whiteListTokenCount ? whiteListTokenCount.toString() : '0'
           }
         />
-
-        <ExploreAllPools
-          numberOfPools={poolsData ? poolsData[0].pool_count.toString() : '0'}
-        />
       </S.ExplorePoolsWrapper>
 
       <ExploreSelectTabs
@@ -154,7 +150,7 @@ export default function Explore() {
         onFilterClick={onClickChainResetPagination}
       />
 
-      {isSelectTab === 'allPools' && selectedView === 'grid' && (
+      {isSelectTab === 'discover' && (
         <div>
           <S.ExploreContainer>
             <TitleSection image={featuredFunds} title="Popular Pools" text="" />
@@ -189,7 +185,7 @@ export default function Explore() {
         <MyPoolsTable selectedChains={selectedChains} />
       )}
 
-      {isSelectTab === 'allPools' && selectedView === 'list' && (
+      {isSelectTab === 'allPools' && (
         <>
           <NewCommunityPoolsTable
             pools={communityPools?.pools}
@@ -211,6 +207,10 @@ export default function Explore() {
           </S.PaginationWrapper>
         </>
       )}
+
+      <ExploreAllPools
+        numberOfPools={poolsData ? poolsData[0].pool_count.toString() : '0'}
+      />
     </S.Explore>
   )
 }

--- a/src/templates/Explore/styles.ts
+++ b/src/templates/Explore/styles.ts
@@ -26,7 +26,7 @@ export const ExploreContainer = styled.div`
   width: 100%;
   background-color: rgba(252, 252, 252, 0.05);
   border-radius: 16px;
-  margin-top: 10rem;
+  margin-top: 5.6rem;
 
   @media (max-width: 576px) {
     padding: 1.6rem;
@@ -43,7 +43,7 @@ export const TitleContainer = styled.div`
   gap: 2.4rem;
   border-radius: 1.6rem;
   border: 0.1rem;
-  margin-block: 5.6rem;
+  margin-block: 3.2rem;
   font-family: 'Rubik';
   border: 1px transparent;
   background: linear-gradient(

--- a/src/templates/Manage/CreatePool/SetDetails/PoolSettings/PoolImage/index.tsx
+++ b/src/templates/Manage/CreatePool/SetDetails/PoolSettings/PoolImage/index.tsx
@@ -51,9 +51,9 @@ const PoolImage = () => {
 
   return (
     <S.PoolImage>
-      <S.PoolSettingTitle>Pool image</S.PoolSettingTitle>
+      <S.PoolSettingTitle>Portfolio image</S.PoolSettingTitle>
       <S.PoolSettingParagraph>
-        Select an image as icon for your pool.
+        Select an image as icon for your portfolio.
       </S.PoolSettingParagraph>
 
       <S.UploadImage>

--- a/src/templates/Manage/CreatePool/StepGuide/index.tsx
+++ b/src/templates/Manage/CreatePool/StepGuide/index.tsx
@@ -30,12 +30,12 @@ const stepGuide = [
   {
     icon: assetsIcon,
     title: 'Step 2 - Select assets',
-    text: 'Choose the assets you want your managed pool to have from our whitelist.'
+    text: 'Choose the assets you want your managed portfolio to have from our whitelist.'
   },
   {
     icon: adjustIcon,
     title: 'Step 3 - Add initial liquidity',
-    text: 'Provide the initial liquidity for your managed pool to work with.'
+    text: 'Provide the initial liquidity for your managed portfolio to work with.'
   },
   {
     icon: feeConfigurationIcon,
@@ -44,7 +44,7 @@ const stepGuide = [
   },
   {
     icon: reviewIcon,
-    title: 'Step 5 - review and create pool',
+    title: 'Step 5 - review and create portfolio',
     text: 'Review and publish it to the network of your choice.'
   }
 ]
@@ -79,7 +79,7 @@ const StepGuide = () => {
   return (
     <S.StepGuide>
       {/* Network icon comes from api */}
-      <CreatePoolHeader title="pool creation step guide" />
+      <CreatePoolHeader title="portfolio creation step guide" />
 
       <S.ContainerCardAndNetwork>
         <S.SelectNetwork>
@@ -87,7 +87,7 @@ const StepGuide = () => {
             <S.Title>Network selection</S.Title>
 
             <S.Text>
-              Choose which network you would like to publish your pool:
+              Choose which network you would like to publish your portfolio:
             </S.Text>
           </S.TextContainer>
 

--- a/src/templates/Manage/GetStarted/index.tsx
+++ b/src/templates/Manage/GetStarted/index.tsx
@@ -51,18 +51,18 @@ const GetStarted = ({ setIsCreatePool }: IGetStartedProps) => {
       <Image src={kacyLogoShadow} width={435} height={400} />
 
       <S.Content>
-        <S.Title>Ready to create your first pool?</S.Title>
+        <S.Title>Ready to create your first portfolio?</S.Title>
 
         <S.Text>
-          It looks like you don't have any pools to manage. Click on the button
-          below to combine tokens to create your first pool to start the journey
-          as a manager.
+          It looks like you don't have any portfolios to manage. Click on the
+          button below to combine tokens to create your first portfolio to start
+          the journey as a manager.
         </S.Text>
 
         <S.ButtonWrapper>
           {wallet?.provider ? (
             <Button
-              text="Create New Pool"
+              text="Create New Portfolio"
               background="secondary"
               fullWidth
               type="button"

--- a/src/templates/Manage/SideBar/index.tsx
+++ b/src/templates/Manage/SideBar/index.tsx
@@ -399,7 +399,7 @@ const SideBar = ({ isOpen, setIsOpen }: ISideBarProps) => {
             />
 
             <SideBarMenu
-              title="My managed pool"
+              title="My managed portfolio"
               icon={poolIcon}
               isSideBarOpen={isOpen}
               isActive={path.length === 75}
@@ -407,7 +407,7 @@ const SideBar = ({ isOpen, setIsOpen }: ISideBarProps) => {
             />
 
             <SideBarMenu
-              title="My Strategy pool"
+              title="My Strategy portfolio"
               icon={poolIcon}
               isSideBarOpen={isOpen}
               isActive={path.length === 75}
@@ -431,13 +431,13 @@ const SideBar = ({ isOpen, setIsOpen }: ISideBarProps) => {
         ) : (
           <S.TextWrapper>
             <S.Text isOpen={isOpen}>
-              Start your journey as an asset pool manager in kassandra's
+              Start your journey as an asset portfolio manager in Kassandra's
               ecosystem.
               <br />
               <br />
               Bring your strategy or develop one as you begin a streamlined
-              process for creating managed pools that utilize digital assets
-              that you can choose from.
+              process for creating managed portfolios that utilize digital
+              assets that you can choose from.
             </S.Text>
           </S.TextWrapper>
         )}
@@ -445,7 +445,7 @@ const SideBar = ({ isOpen, setIsOpen }: ISideBarProps) => {
           <S.ButtonWrapper isOpen={isOpen}>
             {wallet?.provider && managerPools && managerPools.length > 0 && (
               <Button
-                text="Create New Pool"
+                text="Create New Portfolio"
                 background="secondary"
                 fullWidth
                 type="button"

--- a/src/templates/Pool/index.tsx
+++ b/src/templates/Pool/index.tsx
@@ -311,7 +311,7 @@ const Pool = () => {
                     <h3>${pool?.symbol}</h3>
                     {pool?.manager?.id && (
                       <Link
-                        href={`/profile/${pool?.manager.id}?tab=managed-pools`}
+                        href={`/profile/${pool?.manager.id}?tab=managed-portfolios`}
                         passHref
                       >
                         <a>

--- a/src/templates/PoolManager/ActivityCard/index.tsx
+++ b/src/templates/PoolManager/ActivityCard/index.tsx
@@ -196,7 +196,7 @@ const ActivityCard = ({
           </S.ActivityActionTitle>
 
           <PoolInfo
-            title="Pool"
+            title="Portfolio"
             name={pool.name}
             description={pool.symbol}
             logo={pool.logo}

--- a/src/templates/PoolManager/Allocations/AllocationHistory/index.tsx
+++ b/src/templates/PoolManager/Allocations/AllocationHistory/index.tsx
@@ -113,7 +113,7 @@ const AllocationHistory = ({ poolInfo }: IAllocationHistoryProps) => {
           ))
         ) : (
           <S.WasNoAllocationsChange>
-            no change has yet occurred in the allocations of pool assets
+            no change has yet occurred in the allocations of portfolio assets
           </S.WasNoAllocationsChange>
         )}
       </S.ActivityCardContainer>

--- a/src/templates/PoolManager/Analytics/index.tsx
+++ b/src/templates/PoolManager/Analytics/index.tsx
@@ -205,7 +205,7 @@ const Analytics = (props: IAnalyticsProps) => {
         </S.StatsContainer>
       </S.ManagerOverviewContainer>
       <S.TitleWrapper>
-        <TitleSection title="Pool Assets" image={poolsAssetsIcon} />
+        <TitleSection title="Portfolio Assets" image={poolsAssetsIcon} />
       </S.TitleWrapper>
       {dataChainId && (
         <PoolAssets poolId={props.poolId} chainId={dataChainId.chain_id} />

--- a/src/templates/PoolManager/Details/PoolImage/index.tsx
+++ b/src/templates/PoolManager/Details/PoolImage/index.tsx
@@ -130,9 +130,9 @@ const PoolImage = () => {
 
   return (
     <S.PoolImage>
-      <S.PoolSettingTitle>Pool image</S.PoolSettingTitle>
+      <S.PoolSettingTitle>Portfolio image</S.PoolSettingTitle>
       <S.PoolSettingParagraph>
-        Select an image as icon for your pool.
+        Select an image as icon for your portfolio.
       </S.PoolSettingParagraph>
 
       <S.UploadImage>

--- a/src/templates/PoolManager/Details/PoolStrategyControl/index.tsx
+++ b/src/templates/PoolManager/Details/PoolStrategyControl/index.tsx
@@ -63,9 +63,9 @@ const PoolStrategyControl = ({
       <S.PoolStrategyContainer>
         <S.PoolStrategyTitle>Strategy Setting</S.PoolStrategyTitle>
         <S.PoolSettingParagraph>
-          Choose who will be the strategist of the pool. The strategist will
-          have the ability to add, remove, and rebalance tokens in the pool. It
-          can be you or another wallet.
+          Choose who will be the strategist of the portfolio. The strategist
+          will have the ability to add, remove, and rebalance tokens in the
+          portfolio. It can be you or another wallet.
         </S.PoolSettingParagraph>
 
         <S.InputsRadioContainer>
@@ -77,7 +77,7 @@ const PoolStrategyControl = ({
               inputChecked={selected === poolStrategyType.YOURSELF}
               handleClickInput={handleChangeInputValue}
             />
-            <p>You&apos;ll be the owner and strategist of the pool.</p>
+            <p>You&apos;ll be the owner and strategist of the portfolio.</p>
           </S.InputsRadioContent>
           <S.InputsRadioContent>
             <InputRadio
@@ -88,8 +88,8 @@ const PoolStrategyControl = ({
               handleClickInput={handleChangeInputValue}
             />
             <p>
-              You&apos;ll be the owner of the pool, and whoever you add as an
-              address will act as the strategist.
+              You&apos;ll be the owner of the portfolio, and whoever you add as
+              an address will act as the strategist.
             </p>
           </S.InputsRadioContent>
         </S.InputsRadioContainer>

--- a/src/templates/PoolManager/Details/TransferOwnership/index.tsx
+++ b/src/templates/PoolManager/Details/TransferOwnership/index.tsx
@@ -43,16 +43,16 @@ const TransferOwnership = ({
         <S.PoolStrategyTitle>Transfer Ownership</S.PoolStrategyTitle>
         {hasManagerCandidate ? (
           <S.PoolSettingParagraph>
-            Below is the link for the pool candidate to make the claim and
+            Below is the link for the portfolio candidate to make the claim and
             become the new owner, and if you&apos;ve changed your mind, you can
             cancel, this applies until the candidate claims it.
           </S.PoolSettingParagraph>
         ) : (
           <S.PoolSettingParagraph>
             Please provide the address of the individual who will receive
-            ownership of this pool. After the transfer, he will be sent a link
-            provided by us. This link will allow the person to claim and become
-            the new owner of the pool.
+            ownership of this portfolio. After the transfer, he will be sent a
+            link provided by us. This link will allow the person to claim and
+            become the new owner of the portfolio.
           </S.PoolSettingParagraph>
         )}
 

--- a/src/templates/PoolManager/FeeRewards/index.tsx
+++ b/src/templates/PoolManager/FeeRewards/index.tsx
@@ -417,7 +417,7 @@ const FeeRewards = () => {
 
       <S.FeesChartContainer>
         <S.TitleWrapper>
-          <TitleSection title="Pool Assets" image={poolsAssetsIcon} />
+          <TitleSection title="Rewards History" image={poolsAssetsIcon} />
         </S.TitleWrapper>
 
         <FeesChart

--- a/src/templates/PoolManager/ManageAssets/AddLiquidity/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/AddLiquidity/index.tsx
@@ -73,7 +73,7 @@ const AddLiquidity = () => {
 
   return (
     <S.AddLiquidity>
-      <CreatePoolHeader title="Add new assets to the pool" />
+      <CreatePoolHeader title="Add new assets to the portfolio" />
       <Steps
         steps={[
           {
@@ -83,7 +83,7 @@ const AddLiquidity = () => {
           },
           {
             stepNumber: 2,
-            stepeTitle: 'Add liquidity to the pool',
+            stepeTitle: 'Add liquidity to the portfolio',
             state: 'CURRENT'
           },
           {

--- a/src/templates/PoolManager/ManageAssets/ChooseAction/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/ChooseAction/index.tsx
@@ -38,7 +38,7 @@ const ChooseAction = ({
           />
           <h1>Manage Assets</h1>
         </S.HeaderImageContent>
-        <p>Choose an action you would like to start on your pool</p>
+        <p>Choose an action you would like to start on your portfolio</p>
       </S.Header>
       <S.ChooseActionBody>
         <S.CardChooseActionContainer>
@@ -53,20 +53,20 @@ const ChooseAction = ({
           <CardChooseAction
             ImageUrl="/assets/iconGradient/add.svg"
             title="Add asset"
-            paragraph="Select one or more asset you would like to add in the pool to be part of your strategy."
+            paragraph="Select one or more asset you would like to add in the portfolio to be part of your strategy."
             NumberActive={chooseActionStep.Add}
             isActive={actionSelected}
             setChooseActionSelect={setActionSelected}
           />
           <Tippy
-            content="You cannot have less than 2 assets in a managed pool. Currently this pool has only 2 assets."
+            content="You cannot have less than 2 assets in a managed portfolio. Currently this portfolio has only 2 assets."
             disabled={!(amountTokenInPool <= 2)}
           >
             <span>
               <CardChooseAction
                 ImageUrl="/assets/iconGradient/remove.svg"
                 title="remove asset"
-                paragraph="Choose one or more assets you would like to remove from the pool. This is something that."
+                paragraph="Choose one or more assets you would like to remove from the portfolio. This is something that."
                 NumberActive={chooseActionStep.Remove}
                 isActive={actionSelected}
                 setChooseActionSelect={setActionSelected}

--- a/src/templates/PoolManager/ManageAssets/RemoveReview/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/RemoveReview/index.tsx
@@ -26,7 +26,7 @@ const RemoveReview = () => {
 
   return (
     <S.RemoveReview>
-      <CreatePoolHeader title="remove asset from the pool" />
+      <CreatePoolHeader title="remove asset from the portfolio" />
       <Steps
         steps={[
           {

--- a/src/templates/PoolManager/ManageAssets/ReviewAddAsset/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/ReviewAddAsset/index.tsx
@@ -33,7 +33,7 @@ const ReviewAddAsset = () => {
 
   return (
     <S.ReviewAddAsset>
-      <CreatePoolHeader title="Add new assets to the pool" />
+      <CreatePoolHeader title="Add new assets to the portfolio" />
       <Steps
         steps={[
           {
@@ -43,7 +43,7 @@ const ReviewAddAsset = () => {
           },
           {
             stepNumber: 2,
-            stepeTitle: 'Add liquidity to the pool',
+            stepeTitle: 'Add liquidity to the portfolio',
             state: 'PREVIOUS'
           },
           {

--- a/src/templates/PoolManager/ManageAssets/SelectAssets/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/SelectAssets/index.tsx
@@ -138,7 +138,7 @@ const SelectAssets = () => {
 
   return (
     <S.SelectAssets>
-      <CreatePoolHeader title="Add new assets to the pool" />
+      <CreatePoolHeader title="Add new assets to the portfolio" />
 
       <Steps
         steps={[
@@ -149,7 +149,7 @@ const SelectAssets = () => {
           },
           {
             stepNumber: 2,
-            stepeTitle: 'Add liquidity to the pool',
+            stepeTitle: 'Add liquidity to the portfolio',
             state: 'NEXT'
           },
           {
@@ -163,7 +163,7 @@ const SelectAssets = () => {
       <S.TextContainer>
         <S.AddAssetsTitle>Token addition</S.AddAssetsTitle>
         <S.AddAssetsText>
-          Select from the list the asset that will be added to the pool
+          Select from the list the asset that will be added to the portfolio
         </S.AddAssetsText>
       </S.TextContainer>
 

--- a/src/templates/PoolManager/ManageAssets/SetNewWeights/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/SetNewWeights/index.tsx
@@ -147,7 +147,9 @@ const SetNewWeights = () => {
 
       <S.SetNewWeightsBody>
         <h2>Token Weights</h2>
-        <p>Define the new Allocations of the assets that make up the pool</p>
+        <p>
+          Define the new Allocations of the assets that make up the portfolio
+        </p>
 
         <S.AllocationsAndExecutionPeriod>
           <AllocationsTable

--- a/src/templates/PoolManager/ManageAssets/TokenRemoval/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/TokenRemoval/index.tsx
@@ -162,7 +162,7 @@ const TokenRemoval = () => {
 
   return (
     <S.TokenRemoval>
-      <CreatePoolHeader title="remove asset from the pool" />
+      <CreatePoolHeader title="remove asset from the portfolio" />
       <Steps
         steps={[
           {
@@ -179,7 +179,7 @@ const TokenRemoval = () => {
       />
       <S.TokenRemovalsBody>
         <h2>asset removal</h2>
-        <p>Select the token you wish to be removed from the pool</p>
+        <p>Select the token you wish to be removed from the portfolio</p>
 
         <S.SelectTokenAndTableAllocation>
           {poolInfo && (

--- a/src/templates/PoolManager/ManageAssets/index.tsx
+++ b/src/templates/PoolManager/ManageAssets/index.tsx
@@ -135,7 +135,7 @@ const ManageAssets = ({ setIsOpenManageAssets }: IManageAssetsProps) => {
     <ReviewAddAsset key="reviewAddAsset" />,
     <ModalTransactions
       key="modalTransactions"
-      title="To finish the process of adding the asset to the pool do the following:"
+      title="To finish the process of adding the asset to the portfolio do the following:"
       transactionButtonStatus={transactionButtonStatus}
       buttonText={buttonTextActionAdd}
       isCompleted={isCompleted}
@@ -236,7 +236,7 @@ const ManageAssets = ({ setIsOpenManageAssets }: IManageAssetsProps) => {
     <RemoveReview key="RemoveReview" />,
     <ModalTransactions
       key="modalTransactions"
-      title="To finish the process of removing a token from the pool you must complete the following"
+      title="To finish the process of removing a token from the portfolio you must complete the following"
       transactionButtonStatus={transactionButtonStatus}
       buttonText={buttonTextActionRemove}
       isCompleted={isCompleted}

--- a/src/templates/PoolManager/index.tsx
+++ b/src/templates/PoolManager/index.tsx
@@ -394,7 +394,7 @@ const PoolManager = () => {
                       </span>
                     </Tippy>
                   ) : (
-                    <Tippy content="I wanted to remind you that you're not the designated pool strategist.">
+                    <Tippy content="I wanted to remind you that you're not the designated portfolio strategist.">
                       <span>
                         <Button
                           className="btn-manage-assets"

--- a/src/templates/PoolV2/Hero/index.tsx
+++ b/src/templates/PoolV2/Hero/index.tsx
@@ -127,7 +127,7 @@ const Hero = ({ handleClickStakeButton }: IHeroProps) => {
             </S.Chain>
             <S.SymbolAndMade>
               <Link
-                href={`/profile/${pool?.manager.id}?tab=managed-pools`}
+                href={`/profile/${pool?.manager.id}?tab=managed-portfolios`}
                 passHref
               >
                 <a>

--- a/src/templates/Profile/ManagedFunds/index.tsx
+++ b/src/templates/Profile/ManagedFunds/index.tsx
@@ -73,13 +73,13 @@ const ManagedFunds = () => {
         <>
           {isPoolOwner ? (
             <AnyCard
-              text="Looks like you aren’t managing any Pool."
+              text="Looks like you aren’t managing any Portfolio."
               button2
-              buttonText="Create a Pool"
+              buttonText="Create a Portfolio"
               onClick={handleCreatePool}
             />
           ) : (
-            <AnyCard text="This address is not managing any Pool." />
+            <AnyCard text="This address is not managing any Portfolio." />
           )}
         </>
       )}

--- a/src/templates/Profile/Portfolio/index.tsx
+++ b/src/templates/Profile/Portfolio/index.tsx
@@ -218,7 +218,7 @@ const Portfolio = ({
       <S.paddingWrapper>
         <PortfolioHeading
           image={AssetsIcon}
-          title="Indexes"
+          title="Portfolios"
           usd={BNtoDecimal(priceInDolar.tokenizedFunds, 6, 2, 2)}
           tippy="The amount in US Dollars that this address holds in tokenized funds."
         />

--- a/src/templates/Profile/index.tsx
+++ b/src/templates/Profile/index.tsx
@@ -53,8 +53,8 @@ const tabs = [
     icon: walletIcon
   },
   {
-    asPathText: 'managed-pools',
-    text: 'Managed Pools',
+    asPathText: 'managed-portfolios',
+    text: 'Managed Portfolios',
     icon: profileIcon
   },
   {

--- a/src/templates/StakeFarm/AllPools/styles.ts
+++ b/src/templates/StakeFarm/AllPools/styles.ts
@@ -7,10 +7,6 @@ export const Content = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 3.2rem;
-  border-radius: 0.8rem;
-  border: 0.1rem solid rgba(252, 252, 252, 0.08);
-  padding: 2.4rem;
-  background: rgba(252, 252, 252, 0.05);
 
   .button {
     font-family: Rubik;

--- a/src/templates/StakeFarm/ListView/index.tsx
+++ b/src/templates/StakeFarm/ListView/index.tsx
@@ -88,31 +88,39 @@ export function StakeListView() {
         {poolMockData.map(mockData => (
           <S.Content>
             <S.TopContent>
-              <S.PoolNameAndImage>
-                <S.Imagecontainer>
-                  <S.ImageWrapper>
-                    <Image src={mockData.logoUrl} layout="fill" />
-                  </S.ImageWrapper>
+              <S.TopContentMobile>
+                <S.PoolNameAndImage>
+                  <S.Imagecontainer>
+                    <S.ImageWrapper>
+                      <Image src={mockData.logoUrl} layout="fill" />
+                    </S.ImageWrapper>
 
-                  <S.ChainLogoWrapper>
-                    <Image src={mockData.chainLogoUrl} layout="fill" />
-                  </S.ChainLogoWrapper>
-                </S.Imagecontainer>
-                <S.PoolText>
-                  <S.PoolTitle>{mockData.name}</S.PoolTitle>
-                  <S.LabelsContainer>
-                    <GradientLabel
-                      img={{
-                        url: '/assets/iconGradient/lightning.svg',
-                        width: 12,
-                        height: 12
-                      }}
-                      text="STAKE & EARN"
-                    />
-                    <Label text="0,25%" />
-                  </S.LabelsContainer>
-                </S.PoolText>
-              </S.PoolNameAndImage>
+                    <S.ChainLogoWrapper>
+                      <Image src={mockData.chainLogoUrl} layout="fill" />
+                    </S.ChainLogoWrapper>
+                  </S.Imagecontainer>
+                  <S.PoolText>
+                    <S.PoolTitle>{mockData.name}</S.PoolTitle>
+                    <S.LabelsContainer>
+                      <GradientLabel
+                        img={{
+                          url: '/assets/iconGradient/lightning.svg',
+                          width: 12,
+                          height: 12
+                        }}
+                        text="STAKE & EARN"
+                      />
+                      <Label text="0,25%" />
+                    </S.LabelsContainer>
+                  </S.PoolText>
+                </S.PoolNameAndImage>
+                <S.IconWrapperMobile
+                  isExpanded={isExpanded}
+                  onClick={handleExpandToggle}
+                >
+                  <Image src={arrowDownThin} width={24} height={14} />
+                </S.IconWrapperMobile>
+              </S.TopContentMobile>
               <S.RegularContent>
                 <S.RegularColumn>
                   <h3>Voting Power</h3>
@@ -143,12 +151,12 @@ export function StakeListView() {
                 size="large"
                 icon={rightArrowIcon}
               />
-              <S.IconWrapper
+              <S.IconWrapperDesktop
                 isExpanded={isExpanded}
                 onClick={handleExpandToggle}
               >
                 <Image src={arrowDownThin} width={24} height={14} />
-              </S.IconWrapper>
+              </S.IconWrapperDesktop>
             </S.TopContent>
 
             {isExpanded && (

--- a/src/templates/StakeFarm/ListView/index.tsx
+++ b/src/templates/StakeFarm/ListView/index.tsx
@@ -6,35 +6,29 @@ import Label from '@/components/Labels/Label'
 import GradientLabel from '@/components/Labels/GradientLabel'
 import arrowDownThin from '../../../../public/assets/utilities/arrow-down-thin.svg'
 import { useSetChain } from '@web3-onboard/react'
+import Link from 'next/link'
 
-const poolMockData = [
-  {
-    logoUrl: '/assets/logos/kacy-stake.svg',
-    chainLogoUrl: '/assets/logos/avalanche.svg',
-    name: '$KACY',
-    votingPower: '2/',
-    withdrawDelay: '15',
-    earned: 0,
-    apr: 132.94,
-    totalStaked: '702.5 LP-AVAX',
-    stakedInUsd: '43.321 USD',
-    startDate: '13 Nov, 2023',
-    rewardDate: '11 Feb, 2024'
-  },
-  {
-    logoUrl: '/assets/logos/kacy-stake.svg',
-    chainLogoUrl: '/assets/logos/avalanche.svg',
-    name: '$NOTKACY',
-    votingPower: '2/',
-    withdrawDelay: '23',
-    earned: 12,
-    apr: 72.94,
-    totalStaked: '329.13 LP-AVAX',
-    stakedInUsd: '11.891 USD',
-    startDate: '11 Dec, 2023',
-    rewardDate: '29 Mar, 2024'
-  }
-]
+type PoolData = {
+  logoUrl: string
+  chainLogoUrl: string
+  name: string
+  votingPower: string
+  withdrawDelay: string
+  earned: number
+  apr: number
+  totalStaked: string
+  stakedInUsd: string
+  startDate: string
+  rewardDate: string
+  poolReward?: number
+  poolRewardValue?: number
+  contract: string
+}
+
+interface StaleListViewSectionProps {
+  sectionName: string
+  data: PoolData[]
+}
 
 const rightArrowIcon = (
   <svg
@@ -65,16 +59,23 @@ const rightArrowIcon = (
   </svg>
 )
 
-export function StakeListView() {
-  const [isExpanded, setIsExpanded] = useState(false)
+export function StakeListViewSection({
+  sectionName,
+  data
+}: StaleListViewSectionProps) {
+  const [expandedSections, setExpandedSections] = useState<boolean[]>(
+    new Array(data.length).fill(false)
+  )
 
   const [{ settingChain }, setChain] = useSetChain()
 
-  function handleExpandToggle() {
-    setIsExpanded(!isExpanded)
+  function handleExpandToggle(index: number) {
+    const newExpandedSections = [...expandedSections]
+    newExpandedSections[index] = !newExpandedSections[index]
+    setExpandedSections(newExpandedSections)
   }
   return (
-    <S.Wrapper>
+    <S.Wrapper isPowerVotingSection={sectionName === 'Power Voting'}>
       <S.ContentWrapper>
         <S.TitleContent>
           <Image
@@ -83,24 +84,24 @@ export function StakeListView() {
             height={20}
             alt="an icon of a chart pie"
           />{' '}
-          Power Voting
+          {sectionName}
         </S.TitleContent>
-        {poolMockData.map(mockData => (
-          <S.Content>
+        {data.map((pool, index) => (
+          <S.Content key={pool.name}>
             <S.TopContent>
               <S.TopContentMobile>
                 <S.PoolNameAndImage>
                   <S.Imagecontainer>
                     <S.ImageWrapper>
-                      <Image src={mockData.logoUrl} layout="fill" />
+                      <Image src={pool.logoUrl} layout="fill" />
                     </S.ImageWrapper>
 
                     <S.ChainLogoWrapper>
-                      <Image src={mockData.chainLogoUrl} layout="fill" />
+                      <Image src={pool.chainLogoUrl} layout="fill" />
                     </S.ChainLogoWrapper>
                   </S.Imagecontainer>
                   <S.PoolText>
-                    <S.PoolTitle>{mockData.name}</S.PoolTitle>
+                    <S.PoolTitle>{pool.name}</S.PoolTitle>
                     <S.LabelsContainer>
                       <GradientLabel
                         img={{
@@ -115,8 +116,8 @@ export function StakeListView() {
                   </S.PoolText>
                 </S.PoolNameAndImage>
                 <S.IconWrapperMobile
-                  isExpanded={isExpanded}
-                  onClick={handleExpandToggle}
+                  isExpanded={expandedSections[index]}
+                  onClick={() => handleExpandToggle(index)}
                 >
                   <Image src={arrowDownThin} width={24} height={14} />
                 </S.IconWrapperMobile>
@@ -125,23 +126,23 @@ export function StakeListView() {
                 <S.RegularColumn>
                   <h3>Voting Power</h3>
                   <p>
-                    {mockData.votingPower}
-                    <span>{mockData.name}</span>
+                    {pool.votingPower}
+                    <span>{pool.name}</span>
                   </p>
                 </S.RegularColumn>
                 <S.RegularColumn>
                   <h3>Withdraw Delay</h3>
                   <p>
-                    {mockData.withdrawDelay} <span>days</span>
+                    {pool.withdrawDelay} <span>days</span>
                   </p>
                 </S.RegularColumn>
                 <S.RegularColumn>
                   <h3>Earned</h3>
-                  <p>{mockData.earned}</p>
+                  <p>{pool.earned}</p>
                 </S.RegularColumn>
                 <S.BoldColumn>
                   <h3>APR</h3>
-                  <p>{mockData.apr}%</p>
+                  <p>{pool.apr}%</p>
                 </S.BoldColumn>
               </S.RegularContent>
               <Button
@@ -152,52 +153,58 @@ export function StakeListView() {
                 icon={rightArrowIcon}
               />
               <S.IconWrapperDesktop
-                isExpanded={isExpanded}
-                onClick={handleExpandToggle}
+                isExpanded={expandedSections[index]}
+                onClick={() => handleExpandToggle(index)}
               >
                 <Image src={arrowDownThin} width={24} height={14} />
               </S.IconWrapperDesktop>
             </S.TopContent>
 
-            {isExpanded && (
+            {expandedSections[index] && (
               <S.ExpandedWrapper>
                 <S.ExpandedContent>
                   <S.ExpandedTextContent>
                     <S.BlocksWrapper>
                       <S.ExpandedContentBlock>
                         <p>
-                          <span>Total Staked:</span> {mockData.totalStaked}
+                          <span>Total Staked:</span> {pool.totalStaked ?? 0}
                         </p>
 
-                        <span>= {mockData.stakedInUsd} USD</span>
+                        <span>= {pool.stakedInUsd} USD</span>
                       </S.ExpandedContentBlock>
                       <S.ExpandedContentBlock>
                         <p>
-                          <span>Pool Reward:</span> 0/Day
+                          <span>Pool Reward:</span> {pool.poolReward ?? 0}/Day
                         </p>
 
-                        <span>0.00 USD</span>
+                        <span>{pool.poolRewardValue ?? 0} USD</span>
                       </S.ExpandedContentBlock>
                       <S.ExpandedContentBlock>
                         <p>
-                          <span>Start Date:</span> {mockData.startDate}
+                          <span>Start Date:</span> {pool.startDate}
                         </p>
                         <p>
-                          <span>Reward Update:</span> {mockData.rewardDate}
+                          <span>Reward Update:</span> {pool.rewardDate}
                         </p>
                       </S.ExpandedContentBlock>
                     </S.BlocksWrapper>
                     <S.ExpandedFooter>
                       <p>
-                        Buy {mockData.name}{' '}
+                        Buy {pool.name}{' '}
                         <Image
-                          src={mockData.logoUrl}
+                          src={pool.logoUrl}
                           layout="fixed"
                           width={16}
                           height={16}
                         />
                       </p>
-                      <a>See Contract {rightArrowIcon}</a>
+                      <a
+                        target="_blank"
+                        rel="nofollow"
+                        href={'add contract here'}
+                      >
+                        See Contract {rightArrowIcon}
+                      </a>
                     </S.ExpandedFooter>
                   </S.ExpandedTextContent>
                   <S.ExpandedContentButtons>

--- a/src/templates/StakeFarm/ListView/index.tsx
+++ b/src/templates/StakeFarm/ListView/index.tsx
@@ -5,84 +5,207 @@ import Image from 'next/image'
 import Label from '@/components/Labels/Label'
 import GradientLabel from '@/components/Labels/GradientLabel'
 import arrowDownThin from '../../../../public/assets/utilities/arrow-down-thin.svg'
+import { useSetChain } from '@web3-onboard/react'
+
+const poolMockData = [
+  {
+    logoUrl: '/assets/logos/kacy-stake.svg',
+    chainLogoUrl: '/assets/logos/avalanche.svg',
+    name: '$KACY',
+    votingPower: '2/',
+    withdrawDelay: '15',
+    earned: 0,
+    apr: 132.94,
+    totalStaked: '702.5 LP-AVAX',
+    stakedInUsd: '43.321 USD',
+    startDate: '13 Nov, 2023',
+    rewardDate: '11 Feb, 2024'
+  },
+  {
+    logoUrl: '/assets/logos/kacy-stake.svg',
+    chainLogoUrl: '/assets/logos/avalanche.svg',
+    name: '$NOTKACY',
+    votingPower: '2/',
+    withdrawDelay: '23',
+    earned: 12,
+    apr: 72.94,
+    totalStaked: '329.13 LP-AVAX',
+    stakedInUsd: '11.891 USD',
+    startDate: '11 Dec, 2023',
+    rewardDate: '29 Mar, 2024'
+  }
+]
+
+const rightArrowIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15Z"
+      stroke="#FCFCFC"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M8 10.8002L10.8 8.0002L8 5.2002"
+      stroke="#FCFCFC"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M5.2002 8H10.8002"
+      stroke="#FCFCFC"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+)
 
 export function StakeListView() {
   const [isExpanded, setIsExpanded] = useState(false)
+
+  const [{ settingChain }, setChain] = useSetChain()
+
+  function handleExpandToggle() {
+    setIsExpanded(!isExpanded)
+  }
   return (
     <S.Wrapper>
       <S.ContentWrapper>
-        <S.TitleContent>Icon Title</S.TitleContent>
-        <S.Content>
-          <S.PoolNameAndImage>
-            <S.Imagecontainer>
-              <S.ImageWrapper>
-                <Image src="/assets/logos/kacy-stake.svg" layout="fill" />
-              </S.ImageWrapper>
+        <S.TitleContent>
+          <Image
+            src="/assets/icons/pie.svg"
+            width={20}
+            height={20}
+            alt="an icon of a chart pie"
+          />{' '}
+          Power Voting
+        </S.TitleContent>
+        {poolMockData.map(mockData => (
+          <S.Content>
+            <S.TopContent>
+              <S.PoolNameAndImage>
+                <S.Imagecontainer>
+                  <S.ImageWrapper>
+                    <Image src={mockData.logoUrl} layout="fill" />
+                  </S.ImageWrapper>
 
-              <S.ChainLogoWrapper>
-                <Image src="/assets/logos/avalanche.svg" layout="fill" />
-              </S.ChainLogoWrapper>
-            </S.Imagecontainer>
-            <S.PoolText>
-              <S.PoolTitle>$KACY</S.PoolTitle>
-              <S.LabelsContainer>
-                <GradientLabel
-                  img={{
-                    url: '/assets/iconGradient/lightning.svg',
-                    width: 12,
-                    height: 12
-                  }}
-                  text="STAKE & EARN"
-                />
-                <Label text="0,25%" />
-              </S.LabelsContainer>
-            </S.PoolText>
-          </S.PoolNameAndImage>
-          <S.RegularContent>
-            <S.RegularColumn>
-              <h3>Voting Power</h3>
-              <p>
-                2/<span>$KACY</span>
-              </p>
-            </S.RegularColumn>
-            <S.RegularColumn>
-              <h3>Withdraw Delay</h3>
-              <p>
-                15 <span>Days</span>
-              </p>
-            </S.RegularColumn>
-            <S.RegularColumn>
-              <h3>Earned</h3>
-              <p>0</p>
-            </S.RegularColumn>
-            <S.BoldColumn>
-              <h3>APR</h3>
-              <p>132,94%</p>
-            </S.BoldColumn>
-          </S.RegularContent>
-          <S.IconWrapper>
-            <Image src={arrowDownThin} width={14} height={24} />
-          </S.IconWrapper>
-        </S.Content>
+                  <S.ChainLogoWrapper>
+                    <Image src={mockData.chainLogoUrl} layout="fill" />
+                  </S.ChainLogoWrapper>
+                </S.Imagecontainer>
+                <S.PoolText>
+                  <S.PoolTitle>{mockData.name}</S.PoolTitle>
+                  <S.LabelsContainer>
+                    <GradientLabel
+                      img={{
+                        url: '/assets/iconGradient/lightning.svg',
+                        width: 12,
+                        height: 12
+                      }}
+                      text="STAKE & EARN"
+                    />
+                    <Label text="0,25%" />
+                  </S.LabelsContainer>
+                </S.PoolText>
+              </S.PoolNameAndImage>
+              <S.RegularContent>
+                <S.RegularColumn>
+                  <h3>Voting Power</h3>
+                  <p>
+                    {mockData.votingPower}
+                    <span>{mockData.name}</span>
+                  </p>
+                </S.RegularColumn>
+                <S.RegularColumn>
+                  <h3>Withdraw Delay</h3>
+                  <p>
+                    {mockData.withdrawDelay} <span>days</span>
+                  </p>
+                </S.RegularColumn>
+                <S.RegularColumn>
+                  <h3>Earned</h3>
+                  <p>{mockData.earned}</p>
+                </S.RegularColumn>
+                <S.BoldColumn>
+                  <h3>APR</h3>
+                  <p>{mockData.apr}%</p>
+                </S.BoldColumn>
+              </S.RegularContent>
+              <Button
+                rightIcon
+                text="Connect to Avalanche"
+                background="secondary"
+                size="large"
+                icon={rightArrowIcon}
+              />
+              <S.IconWrapper
+                isExpanded={isExpanded}
+                onClick={handleExpandToggle}
+              >
+                <Image src={arrowDownThin} width={24} height={14} />
+              </S.IconWrapper>
+            </S.TopContent>
+
+            {isExpanded && (
+              <S.ExpandedWrapper>
+                <S.ExpandedContent>
+                  <S.ExpandedTextContent>
+                    <S.BlocksWrapper>
+                      <S.ExpandedContentBlock>
+                        <p>
+                          <span>Total Staked:</span> {mockData.totalStaked}
+                        </p>
+
+                        <span>= {mockData.stakedInUsd} USD</span>
+                      </S.ExpandedContentBlock>
+                      <S.ExpandedContentBlock>
+                        <p>
+                          <span>Pool Reward:</span> 0/Day
+                        </p>
+
+                        <span>0.00 USD</span>
+                      </S.ExpandedContentBlock>
+                      <S.ExpandedContentBlock>
+                        <p>
+                          <span>Start Date:</span> {mockData.startDate}
+                        </p>
+                        <p>
+                          <span>Reward Update:</span> {mockData.rewardDate}
+                        </p>
+                      </S.ExpandedContentBlock>
+                    </S.BlocksWrapper>
+                    <S.ExpandedFooter>
+                      <p>
+                        Buy {mockData.name}{' '}
+                        <Image
+                          src={mockData.logoUrl}
+                          layout="fixed"
+                          width={16}
+                          height={16}
+                        />
+                      </p>
+                      <a>See Contract {rightArrowIcon}</a>
+                    </S.ExpandedFooter>
+                  </S.ExpandedTextContent>
+                  <S.ExpandedContentButtons>
+                    <Button size="large" text="Claim" background="secondary" />
+                    <Button
+                      size="large"
+                      text="Request Withdraw"
+                      background="secondary"
+                    />
+                  </S.ExpandedContentButtons>
+                </S.ExpandedContent>
+              </S.ExpandedWrapper>
+            )}
+          </S.Content>
+        ))}
       </S.ContentWrapper>
-
-      {isExpanded && (
-        <S.ExpandedContent>
-          <S.ExpandedTextContent>
-            <S.ExpandedContentBlock></S.ExpandedContentBlock>
-            <S.ExpandedContentBlock></S.ExpandedContentBlock>
-            <S.ExpandedContentBlock></S.ExpandedContentBlock>
-            <S.ExpandedFooter>
-              <p>Buy NAME ICON</p>
-              <a>See Contract ICON</a>
-            </S.ExpandedFooter>
-          </S.ExpandedTextContent>
-          <S.ExpandedContentButtons>
-            <Button text="Claim" />
-            <Button text="Request Withdraw" />
-          </S.ExpandedContentButtons>
-        </S.ExpandedContent>
-      )}
     </S.Wrapper>
   )
 }

--- a/src/templates/StakeFarm/ListView/styles.ts
+++ b/src/templates/StakeFarm/ListView/styles.ts
@@ -6,6 +6,14 @@ export const Wrapper = styled.div`
   gap: 3.2rem;
   background: rgba(252, 252, 252, 0.05);
   padding: 4rem;
+
+  @media (max-width: 960px) {
+    padding: 2.4rem;
+  }
+
+  @media (max-width: 560px) {
+    padding: 1.6rem;
+  }
 `
 
 export const ContentWrapper = styled.div`
@@ -30,10 +38,6 @@ export const TitleContent = styled.div`
 `
 
 export const Content = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
   width: 100%;
   border-radius: 1.6rem;
   background: rgba(0, 0, 0, 0.25);
@@ -42,12 +46,35 @@ export const Content = styled.div`
 
 export const TopContent = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: 11.6rem;
   padding-inline: 1.6rem;
+  padding-block: 3.2rem;
+  justify-content: space-between;
+
+  @media (max-width: 560px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2.4rem;
+    padding-block: 2.4rem;
+
+    button {
+      display: none;
+    }
+  }
 `
+
+export const TopContentMobile = styled.div`
+  display: hidden;
+
+  @media (max-width: 960px) {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    align-items: center;
+  }
+`
+
 export const PoolNameAndImage = styled.div`
   display: flex;
   gap: 2.4rem;
@@ -113,6 +140,10 @@ export const LabelsContainer = styled.div`
 export const RegularContent = styled.div`
   display: flex;
   gap: 4.8rem;
+
+  @media (max-width: 960px) {
+    gap: 1.6rem;
+  }
 `
 export const RegularColumn = styled.div`
   display: flex;
@@ -153,7 +184,7 @@ interface IconWrapperProps {
   isExpanded?: boolean
 }
 
-export const IconWrapper = styled.div<IconWrapperProps>`
+export const IconWrapperDesktop = styled.div<IconWrapperProps>`
   position: relative;
   display: flex;
   width: 2.4rem;
@@ -162,6 +193,17 @@ export const IconWrapper = styled.div<IconWrapperProps>`
   img {
     ${props => (props.isExpanded ? `transform: rotate(180deg)` : null)};
     transition: transform 300ms ease-in-out;
+  }
+
+  @media (max-width: 960px) {
+    display: none;
+  }
+`
+
+export const IconWrapperMobile = styled(IconWrapperDesktop)`
+  display: none;
+  @media (max-width: 960px) {
+    display: flex;
   }
 `
 
@@ -197,7 +239,6 @@ export const ExpandedContentBlock = styled.div`
   width: 100%;
   background: rgba(252, 252, 252, 0.05);
   border: 1px solid rgba(252, 252, 252, 0.15);
-  height: 9.2rem;
   border-radius: 0.8rem;
   font-size: 1.6rem;
   font-weight: 300;

--- a/src/templates/StakeFarm/ListView/styles.ts
+++ b/src/templates/StakeFarm/ListView/styles.ts
@@ -19,6 +19,7 @@ export const ContentWrapper = styled.div`
 
 export const TitleContent = styled.div`
   display: flex;
+  align-items: center;
   gap: 1.6rem;
   height: 4rem;
   border-bottom: 1px solid rgba(252, 252, 252, 0.05);
@@ -30,13 +31,22 @@ export const TitleContent = styled.div`
 
 export const Content = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
-  padding-inline: 1.6rem;
-  padding-block: 3.2rem;
   border-radius: 1.6rem;
   background: rgba(0, 0, 0, 0.25);
   border: 1px solid rgba(252, 252, 252, 0.08);
+`
+
+export const TopContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 11.6rem;
+  padding-inline: 1.6rem;
 `
 export const PoolNameAndImage = styled.div`
   display: flex;
@@ -108,6 +118,7 @@ export const RegularColumn = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 0.8rem;
 
   h3 {
     font-family: Rubik;
@@ -138,13 +149,91 @@ export const BoldColumn = styled(RegularColumn)`
   }
 `
 
-export const IconWrapper = styled.div`
-  width: 1.4rem;
-  height: 2.4rem;
+interface IconWrapperProps {
+  isExpanded?: boolean
+}
+
+export const IconWrapper = styled.div<IconWrapperProps>`
+  position: relative;
+  display: flex;
+  width: 2.4rem;
+  height: 1.4rem;
+
+  img {
+    ${props => (props.isExpanded ? `transform: rotate(180deg)` : null)};
+    transition: transform 300ms ease-in-out;
+  }
 `
 
-export const ExpandedContent = styled.div``
-export const ExpandedTextContent = styled.div``
-export const ExpandedContentBlock = styled.div``
-export const ExpandedFooter = styled.div``
-export const ExpandedContentButtons = styled.div``
+export const ExpandedWrapper = styled.div`
+  width: 100%;
+  border-top: 1px solid rgba(252, 252, 252, 0.08);
+`
+
+export const ExpandedContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-inline: 1.6rem;
+  padding-block: 2.4rem;
+  gap: 3.2rem;
+`
+export const ExpandedTextContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
+`
+
+export const BlocksWrapper = styled.div`
+  display: flex;
+  gap: 3.2rem;
+  width: 100%;
+`
+export const ExpandedContentBlock = styled.div`
+  padding: 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  width: 100%;
+  background: rgba(252, 252, 252, 0.05);
+  border: 1px solid rgba(252, 252, 252, 0.15);
+  height: 9.2rem;
+  border-radius: 0.8rem;
+  font-size: 1.6rem;
+  font-weight: 300;
+  line-height: 1.8rem;
+
+  p {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  span {
+    font-weight: 500;
+    color: #fcfcfc;
+  }
+`
+export const ExpandedFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.6rem;
+  font-weight: 300;
+  line-height: 1.6rem;
+
+  a,
+  p {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+`
+export const ExpandedContentButtons = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+
+  button {
+    max-width: 28.6rem;
+    min-width: 20rem;
+  }
+`

--- a/src/templates/StakeFarm/ListView/styles.ts
+++ b/src/templates/StakeFarm/ListView/styles.ts
@@ -1,10 +1,15 @@
 import styled, { css } from 'styled-components'
 
-export const Wrapper = styled.div`
+interface WrapperProps {
+  isPowerVotingSection?: boolean
+}
+
+export const Wrapper = styled.div<WrapperProps>`
   display: flex;
   flex-direction: column;
   gap: 3.2rem;
-  background: rgba(252, 252, 252, 0.05);
+  background: ${props =>
+    props.isPowerVotingSection ? `rgba(252, 252, 252, 0.05)` : null};
   padding: 4rem;
 
   @media (max-width: 960px) {
@@ -52,7 +57,7 @@ export const TopContent = styled.div`
   padding-block: 3.2rem;
   justify-content: space-between;
 
-  @media (max-width: 560px) {
+  @media (max-width: 568px) {
     flex-direction: column;
     align-items: flex-start;
     gap: 2.4rem;
@@ -67,7 +72,7 @@ export const TopContent = styled.div`
 export const TopContentMobile = styled.div`
   display: hidden;
 
-  @media (max-width: 960px) {
+  @media (max-width: 768px) {
     display: flex;
     justify-content: space-between;
     width: 100%;
@@ -141,7 +146,7 @@ export const RegularContent = styled.div`
   display: flex;
   gap: 4.8rem;
 
-  @media (max-width: 960px) {
+  @media (max-width: 768px) {
     gap: 1.6rem;
   }
 `
@@ -191,18 +196,19 @@ export const IconWrapperDesktop = styled.div<IconWrapperProps>`
   height: 1.4rem;
 
   img {
+    cursor: pointer;
     ${props => (props.isExpanded ? `transform: rotate(180deg)` : null)};
     transition: transform 300ms ease-in-out;
   }
 
-  @media (max-width: 960px) {
+  @media (max-width: 560px) {
     display: none;
   }
 `
 
 export const IconWrapperMobile = styled(IconWrapperDesktop)`
   display: none;
-  @media (max-width: 960px) {
+  @media (max-width: 560px) {
     display: flex;
   }
 `
@@ -218,6 +224,10 @@ export const ExpandedContent = styled.div`
   padding-inline: 1.6rem;
   padding-block: 2.4rem;
   gap: 3.2rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 `
 export const ExpandedTextContent = styled.div`
   display: flex;
@@ -230,6 +240,10 @@ export const BlocksWrapper = styled.div`
   display: flex;
   gap: 3.2rem;
   width: 100%;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 `
 export const ExpandedContentBlock = styled.div`
   padding: 1.6rem;
@@ -267,6 +281,11 @@ export const ExpandedFooter = styled.div`
     align-items: center;
     gap: 1rem;
   }
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
 `
 export const ExpandedContentButtons = styled.div`
   display: flex;
@@ -276,5 +295,16 @@ export const ExpandedContentButtons = styled.div`
   button {
     max-width: 28.6rem;
     min-width: 20rem;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: row;
+    justify-content: space-between;
+
+    button {
+      min-width: 10rem;
+      max-width: none;
+      width: 100%;
+    }
   }
 `

--- a/src/templates/StakeFarm/index.tsx
+++ b/src/templates/StakeFarm/index.tsx
@@ -14,8 +14,7 @@ import { useVotingPower } from '@/hooks/query/useVotingPower'
 import * as S from './styles'
 import { StakeFarmPools } from './AllPools'
 import { allPools } from '@/constants/pools'
-import { NewSelectTabs } from '@/components/NewSelectTabs'
-import { StakeListView } from './ListView'
+import { StakeListViewSection } from './ListView'
 import { ViewOptions } from '@/components/NewSelectTabs/ViewOptions'
 
 const tabs = [
@@ -52,6 +51,57 @@ const StakeFarm = () => {
     }
   }, [router])
 
+  const fakePoolsData = [
+    {
+      logoUrl: '/assets/logos/kacy-stake.svg',
+      chainLogoUrl: '/assets/logos/avalanche.svg',
+      name: '$KACY',
+      votingPower: '2/',
+      withdrawDelay: '15',
+      earned: 0,
+      apr: 132.94,
+      totalStaked: '702.5 LP-AVAX',
+      stakedInUsd: '43.321 USD',
+      startDate: '13 Nov, 2023',
+      rewardDate: '11 Feb, 2024',
+      poolReward: 0,
+      poolRewardValue: 0,
+      contract: '0x384572384203409123098123'
+    },
+    {
+      logoUrl: '/assets/logos/kacy-stake.svg',
+      chainLogoUrl: '/assets/logos/avalanche.svg',
+      name: '$NOTKACY',
+      votingPower: '3/',
+      withdrawDelay: '23',
+      earned: 12,
+      apr: 72.94,
+      totalStaked: '329.13 LP-AVAX',
+      stakedInUsd: '11.891 USD',
+      startDate: '11 Dec, 2023',
+      rewardDate: '29 Mar, 2024',
+      poolReward: 1,
+      poolRewardValue: 23,
+      contract: '0x23423438457238420098123'
+    },
+    {
+      logoUrl: '/assets/logos/kacy-stake.svg',
+      chainLogoUrl: '/assets/logos/avalanche.svg',
+      name: '$ANOTHAKCY',
+      votingPower: '4/',
+      withdrawDelay: '69',
+      earned: 3,
+      apr: 81.12,
+      totalStaked: '163 LP-AVAX',
+      stakedInUsd: '2.341 USD',
+      startDate: '11 Dec, 2023',
+      rewardDate: '29 Mar, 2024',
+      poolReward: 2,
+      poolRewardValue: 55,
+      contract: '0x546546456384572389123'
+    }
+  ]
+
   return (
     <>
       <Breadcrumb>
@@ -87,7 +137,22 @@ const StakeFarm = () => {
         <StakeFarmPools numberOfPools={allPoolsNumber} />
       </S.TabsContainer>
 
-      {selectedView === 'list' && <StakeListView />}
+      {selectedView === 'list' && (
+        <>
+          <StakeListViewSection
+            data={fakePoolsData}
+            sectionName="Power Voting"
+          />
+          <StakeListViewSection
+            data={fakePoolsData}
+            sectionName="KACY Liquidity"
+          />
+          <StakeListViewSection
+            data={fakePoolsData}
+            sectionName="Investment Pool"
+          />
+        </>
+      )}
 
       <S.StakeFarm>
         {selectedView === 'grid' && <Stake />}

--- a/src/templates/StakeFarm/index.tsx
+++ b/src/templates/StakeFarm/index.tsx
@@ -80,11 +80,11 @@ const StakeFarm = () => {
       </S.StakeFarmHeader>
 
       <S.TabsContainer>
-        <StakeFarmPools numberOfPools={allPoolsNumber} />
         <ViewOptions
           selectedView={selectedView}
           setSelectedView={setSelectedView}
         />
+        <StakeFarmPools numberOfPools={allPoolsNumber} />
       </S.TabsContainer>
 
       {selectedView === 'list' && <StakeListView />}

--- a/src/templates/StakeFarm/styles.ts
+++ b/src/templates/StakeFarm/styles.ts
@@ -66,11 +66,16 @@ export const SubTitle = styled.h2`
 
 export const TabsContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   max-width: 114rem;
   margin-inline: auto;
   margin-block: 5.6rem;
   gap: 2.4rem;
+  border-radius: 0.8rem;
+  border: 0.1rem solid rgba(252, 252, 252, 0.08);
+  padding: 2.4rem;
+  background: rgba(252, 252, 252, 0.05);
 
   @media (max-width: 976px) {
     padding-inline: 2.4rem;


### PR DESCRIPTION
## Why

Stake page design changes, rename pool -> portfolio, QA changes.

## Changes

- [x] New feature (non-breaking change which adds functionality)
  1. A few QA related changes, including reducing margin and padding, general layout changes, removal of the view options, inclusion of a CTA section, addition of a new tab and renaming of the older tabs. 
  2. Change texts from `pool` to `portfolio` where applicable
  3. Conclusion of the bare Stake list view (without functionalities or real data) for desktop and mobile (no tablet yet)